### PR TITLE
mlx window에 기본 이미지 띄우기 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,12 @@ MLX_DIR		:= ./lib/mlx_mms
 
 
 # ===== Packages =====
-PKGS		:= event list vector3 #parse
+PKGS		:= event list scene trace vector3
 
-eventV		:= hook_key_n_exit
+eventV		:= draw draw_util hook_key_n_exit
 listV		:= list_utils
-# parseV		:= parse
+sceneV		:= scene
+traceV		:= ray
 vector3V	:= vector_operation1 vector_operation2 vector_operation3 vector_set
 
 

--- a/include/event.h
+++ b/include/event.h
@@ -1,13 +1,34 @@
 #ifndef EVENT_H
 # define EVENT_H
 
+# define WIN_WIDTH	1920
+# define WIN_HEIGHT	1080
+
+typedef struct s_image
+{
+	void	*img;
+	char	*addr;
+	int		bpp;
+	int		line;
+	int		endian;
+}	t_image;
+
 typedef struct s_mlx
 {
 	void	*mlx;
 	void	*win;
+	t_image	img;
 }	t_mlx;
 
-int	key_press(int keycode, t_mlx *mlx);
-int	exit_button(void);
+// draw.c
+
+void	scene_draw(t_mlx *mlx);
+int		color_calc(double rgb);
+void	my_mlx_pixel_put(t_image *image, int x, int y, int color);
+
+// hook_key_n_exit.c
+
+int		key_press(int keycode, t_mlx *mlx);
+int		exit_button(void);
 
 #endif

--- a/include/scene.h
+++ b/include/scene.h
@@ -1,0 +1,11 @@
+#ifndef SCENE_H
+# define SCENE_H
+
+# include "structure.h"
+
+t_canvas	canvas_set(int width, int height);
+t_camera	camera_set(
+				t_canvas *canvas, t_point3 origin, t_vec3 direct, double h_fov);
+t_scene		*new_scene(int width, int height);
+
+#endif

--- a/include/structure.h
+++ b/include/structure.h
@@ -32,4 +32,37 @@ typedef struct s_obj_list
 	void	*next;
 }t_obj_list;
 
+typedef struct s_canvas
+{
+	int		width;
+	int		height;
+	double	aspect_ratio;
+}	t_canvas;
+
+typedef struct s_camera
+{
+	t_point3	origin;
+	double		viewport_height;
+	double		viewport_width;
+	t_vec3		w_direction;
+	t_vec3		u_upside;
+	t_vec3		v_cross;
+	t_vec3		horizontal;
+	t_vec3		vertical;
+	t_point3	left_bottom;
+}	t_camera;
+
+typedef struct s_ray
+{
+	t_point3	origin;
+	t_vec3		direction;
+}	t_ray;
+
+typedef struct s_scene
+{
+	t_canvas	canvas;
+	t_camera	camera;
+	t_ray		ray;
+}	t_scene;
+
 #endif

--- a/include/trace.h
+++ b/include/trace.h
@@ -1,0 +1,10 @@
+#ifndef TRACE_H
+# define TRACE_H
+
+# include "structure.h"
+
+t_ray		ray_set(t_point3 origin, t_vec3 direction);
+t_ray		ray_primary(t_camera *cam, double alpha, double beta);
+t_color3	ray_color(t_scene *scene);
+
+#endif

--- a/include/vector3.h
+++ b/include/vector3.h
@@ -7,7 +7,7 @@
 
 t_vec3		vec3(double x, double y, double z);
 t_point3	point3(double x, double y, double z);
-t_point3	color3(double r, double g, double b);
+t_color3	color3(double r, double g, double b);
 void		vec3_set(t_vec3 *vec, double x, double y, double z);
 
 // vector_operation1.c

--- a/src/event/draw.c
+++ b/src/event/draw.c
@@ -1,0 +1,54 @@
+#include <stdlib.h>
+#include "mlx.h"
+#include "event.h"
+#include "scene.h"
+#include "trace.h"
+
+static int	get_color(t_color3 pixel_color)
+{
+	int	color;
+
+	color = 0;
+	color |= color_calc(pixel_color.x) << 16;
+	color |= color_calc(pixel_color.y) << 8;
+	color |= color_calc(pixel_color.z);
+	return (color);
+}
+
+static void	ray_trace(t_mlx *mlx, t_scene *scene, int row, int col)
+{
+	double		alpha;
+	double		beta;
+	t_color3	pixel_color;
+
+	alpha = (double)col / (WIN_WIDTH - 1);
+	beta = (double)row / (WIN_HEIGHT - 1);
+	scene->ray = ray_primary(&scene->camera, alpha, beta);
+	pixel_color = ray_color(scene);
+	my_mlx_pixel_put(
+		&mlx->img, col, WIN_HEIGHT - 1 - row, get_color(pixel_color));
+}
+
+static void	scene_create(t_mlx *mlx)
+{
+	t_scene	*scene;
+	int		row;
+	int		col;
+
+	scene = new_scene(WIN_WIDTH, WIN_HEIGHT);
+	row = WIN_HEIGHT - 1;
+	while (row >= 0)
+	{
+		col = -1;
+		while (++col < WIN_WIDTH)
+			ray_trace(mlx, scene, row, col);
+		row--;
+	}
+	free(scene);
+}
+
+void	scene_draw(t_mlx *mlx)
+{
+	scene_create(mlx);
+	mlx_put_image_to_window(mlx->mlx, mlx->win, mlx->img.img, 0, 0);
+}

--- a/src/event/draw_util.c
+++ b/src/event/draw_util.c
@@ -1,0 +1,19 @@
+#include "event.h"
+
+void	my_mlx_pixel_put(t_image *image, int x, int y, int color)
+{
+	char	*dst;
+
+	dst = image->addr + (y * image->line + x * (image->bpp / 8));
+	*(unsigned int *)dst = color;
+}
+
+int	color_calc(double rgb)
+{
+	int	color;
+
+	color = (int)(256 * rgb);
+	if (color > 255)
+		color = 255;
+	return (color);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -2,13 +2,21 @@
 #include "x11_events.h"
 #include "event.h"
 
+static void	program_init(t_mlx *mlx)
+{
+	mlx->mlx = mlx_init();
+	mlx->img.img = mlx_new_image(mlx->mlx, WIN_WIDTH, WIN_HEIGHT);
+	mlx->img.addr = mlx_get_data_addr(
+			mlx->img.img, &mlx->img.bpp, &mlx->img.line, &mlx->img.endian);
+	mlx->win = mlx_new_window(mlx->mlx, WIN_WIDTH, WIN_HEIGHT, "miniRT");
+}
+
 int	main(void)
 {
 	t_mlx	mlx;
 
-	mlx.mlx = mlx_init();
-	mlx.win = mlx_new_window(mlx.mlx, 1920, 1080, "miniRT");
-
+	program_init(&mlx);
+	scene_draw(&mlx);
 	mlx_hook(mlx.win, X11_KEYPRESS, 1L << 0, key_press, &mlx);
 	mlx_hook(mlx.win, X11_CLOSEBTN, 1L << 2, exit_button, &mlx);
 	mlx_loop(mlx.mlx);

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -1,0 +1,54 @@
+#include <math.h>
+#include "scene.h"
+#include "vector3.h"
+#include "libft.h"
+
+t_scene	*new_scene(int width, int height)
+{
+	t_scene	*scene;
+
+	scene = ft_calloc(sizeof(t_scene), 0);
+	scene->canvas = canvas_set(width, height);
+	scene->camera = camera_set(&scene->canvas, point3(0, 0, 0), vec3_unit(vec3(0, 0, -1)), 90);
+	return (scene);
+}
+
+t_canvas	canvas_set(int width, int height)
+{
+	t_canvas	canvas;
+
+	canvas.width = width;
+	canvas.height = height;
+	canvas.aspect_ratio = (double)height / (double)width;
+	return (canvas);
+}
+
+static double	degree_to_radian(double degree)
+{
+	return (degree * M_PI / 180);
+}
+
+t_camera
+	camera_set(t_canvas *canvas, t_point3 origin, t_vec3 direct, double h_fov)
+{
+	t_camera	cam;
+	double		theta;
+	double		field_width;
+	t_vec3		default_upside;
+
+	theta = degree_to_radian(h_fov);
+	field_width = tan(theta / 2) * 2.0;
+	default_upside = vec3(0, 1, 0);
+	cam.w_direction = direct;
+	cam.u_upside = vec3_unit(vec3_cross(default_upside, cam.w_direction));
+	cam.v_cross = vec3_unit(vec3_cross(cam.w_direction, cam.u_upside));
+	cam.origin = origin;
+	cam.viewport_width = field_width;
+	cam.viewport_height = field_width * canvas->aspect_ratio;
+	cam.horizontal = vec3_mult_scalar(cam.u_upside, cam.viewport_width);
+	cam.vertical = vec3_mult_scalar(cam.v_cross, cam.viewport_height);
+	cam.left_bottom = vec3_minus(cam.origin, vec3_plus(
+				vec3_divide_scalar(vec3_plus(cam.horizontal, cam.vertical), 2),
+				cam.w_direction));
+	return (cam);
+}

--- a/src/trace/ray.c
+++ b/src/trace/ray.c
@@ -1,0 +1,31 @@
+#include "trace.h"
+#include "vector3.h"
+
+t_ray	ray_set(t_point3 origin, t_vec3 direction)
+{
+	t_ray	ray;
+
+	ray.origin = origin;
+	ray.direction = direction;
+	return (ray);
+}
+
+t_ray	ray_primary(t_camera *cam, double alpha, double beta)
+{
+	t_ray	ray;
+
+	ray.origin = cam->origin;
+	ray.direction = vec3_unit(vec3_minus(vec3_plus(vec3_plus(cam->left_bottom,
+						vec3_mult_scalar(cam->horizontal, alpha)),
+					vec3_mult_scalar(cam->vertical, beta)), cam->origin));
+	return (ray);
+}
+
+t_color3	ray_color(t_scene *scene)
+{
+	double	t;
+
+	t = 0.5 * (scene->ray.direction.y + 1.0);
+	return (vec3_plus(vec3_mult_scalar(color3(1, 1, 1), 1.0 - t),
+			vec3_mult_scalar(color3(0.5, 0.7, 1.0), t)));
+}

--- a/src/vector3/vector_set.c
+++ b/src/vector3/vector_set.c
@@ -20,7 +20,7 @@ t_point3	point3(double x, double y, double z)
 	return (point);
 }
 
-t_point3	color3(double r, double g, double b)
+t_color3	color3(double r, double g, double b)
 {
 	t_color3	color;
 


### PR DESCRIPTION
### 개요
mlx를 이용해 ppm이 아닌 창으로 이미지 띄우기
- 기본 canvas, camera 세팅
- camera 위치, 방향, 시야각 조절 가능
- 아직 object 없음

### 폴더 구성
```c
🗂 event: mlx를 사용하는 함수
⎿ draw.c: 특정 scene을 생성하고 image에 그려서 window로 전환
⎿ draw_util.c: 결과를 찍어낼 때 사용할 도구

🗂 scene
⎿ scene.c: 기본적인 scene을 생성하는 함수로, 현재 canvas, camera 세팅까지 진행

🗂 trace
⎿ ray.c:  primary ray 생성, 색 결정 함수
```

### 결과
![image](https://user-images.githubusercontent.com/76509884/159670594-6fd21f8a-896e-463d-ab20-edbd4ed52833.png)


- closes #14