### PR TITLE
sphere, phong illumination model, hard shadow 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ PKGS		:= event list scene trace parse vector3
 
 eventV		:= draw draw_util hook_key_n_exit
 listV		:= list_utils
-sceneV		:= scene
-traceV		:= ray
+sceneV		:= object scene
+traceV		:= hit_sphere hit phong_illumination phong_light ray
 parseV		:= parse parse_read
 vector3V	:= vector_operation1 vector_operation2 vector_operation3 vector_set
 

--- a/include/scene.h
+++ b/include/scene.h
@@ -3,9 +3,17 @@
 
 # include "structure.h"
 
+// scene.c
+
 t_canvas	canvas_set(int width, int height);
 t_camera	camera_set(
 				t_canvas *canvas, t_point3 origin, t_vec3 direct, double h_fov);
 t_scene		*new_scene(int width, int height);
+
+// object.c
+
+t_obj_list	*new_object(t_obj_type type, void *object, t_color3 color);
+t_light		*new_point_light(t_point3 light_origin, double bright_ratio);
+t_sphere	*new_sphere(t_point3 center, double radius);
 
 #endif

--- a/include/structure.h
+++ b/include/structure.h
@@ -1,6 +1,10 @@
 #ifndef STRUCTURE_H
 # define STRUCTURE_H
 
+# include "libft_type.h"
+
+# define EPSILON 1e-6
+
 typedef struct s_vec3	t_vec3;
 typedef struct s_vec3	t_point3;
 typedef struct s_vec3	t_color3;
@@ -26,7 +30,7 @@ typedef struct s_parse
 
 typedef enum e_obj_type
 {
-	LIGHT = 0,
+	POINT_LIGHT = 0,
 	SPHERE = 1,
 	PLANE = 2,
 	CYLINDER = 3,
@@ -66,6 +70,17 @@ typedef struct s_ray
 	t_vec3		direction;
 }	t_ray;
 
+typedef struct s_hit_record
+{
+	t_point3	p;
+	t_vec3		normal;
+	double		tmin;
+	double		tmax;
+	double		t;
+	t_bool		front_face;
+	t_color3	color;
+}	t_hit_record;
+
 typedef struct s_ambient
 {
 	double		light_ratio;
@@ -102,12 +117,16 @@ typedef struct s_cylinder
 
 typedef struct s_scene
 {
-	t_canvas	canvas;
-	t_camera	camera;
-	t_obj_list	*object;
-	t_obj_list	*light;
-	t_ambient	ambient;
-	t_ray		ray;
+	t_canvas		canvas;
+	t_camera		camera;
+	t_obj_list		*objects;
+	t_obj_list		*lights;
+	t_ambient		ambient;
+	t_ray			ray;
+	t_hit_record	record;
 }	t_scene;
+
+typedef t_bool			(*t_obj_hit_f)(
+		t_obj_list *objects, t_ray *ray, t_hit_record *rec);
 
 #endif

--- a/include/trace.h
+++ b/include/trace.h
@@ -3,8 +3,31 @@
 
 # include "structure.h"
 
+// ray.c
+
 t_ray		ray_set(t_point3 origin, t_vec3 direction);
 t_ray		ray_primary(t_camera *cam, double alpha, double beta);
-t_color3	ray_color(t_scene *scene);
+t_point3	ray_at(t_ray *ray, double t);
+t_color3	ray_tracing(t_scene *scene);
+
+// hit.c
+
+t_bool		hit(t_obj_list objects[], t_ray *ray, t_hit_record *record);
+t_bool		object_hit(t_obj_list objects[], t_ray *ray, t_hit_record *record);
+
+// hit_*.c
+
+t_bool		hit_sphere(t_obj_list objects[], t_ray *ray, t_hit_record *rec);
+
+// phong_illumination.c
+
+t_color3	phong_illumination_model(t_scene *scene);
+t_color3	point_light_get(t_scene *scene, t_obj_list *light);
+
+// phong_light.c
+
+t_color3	phong_diffuse(t_scene *scene, t_obj_list *light, t_vec3 light_dir);
+t_color3	phong_specular(t_scene *scene, t_obj_list *light, t_vec3 light_dir);
+t_bool		is_in_shadow(t_scene *scene, t_vec3 light_dir);
 
 #endif

--- a/src/event/draw.c
+++ b/src/event/draw.c
@@ -3,6 +3,7 @@
 #include "event.h"
 #include "scene.h"
 #include "trace.h"
+#include "list.h"
 
 static int	get_color(t_color3 pixel_color)
 {
@@ -24,7 +25,7 @@ static void	ray_trace(t_mlx *mlx, t_scene *scene, int row, int col)
 	alpha = (double)col / (WIN_WIDTH - 1);
 	beta = (double)row / (WIN_HEIGHT - 1);
 	scene->ray = ray_primary(&scene->camera, alpha, beta);
-	pixel_color = ray_color(scene);
+	pixel_color = ray_tracing(scene);
 	my_mlx_pixel_put(
 		&mlx->img, col, WIN_HEIGHT - 1 - row, get_color(pixel_color));
 }
@@ -44,6 +45,8 @@ static void	scene_create(t_mlx *mlx)
 			ray_trace(mlx, scene, row, col);
 		row--;
 	}
+	obj_list_clear(&scene->objects);
+	obj_list_clear(&scene->lights);
 	free(scene);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -14,18 +14,15 @@ static void	program_init(t_mlx *mlx)
 
 int	main(int argv, char **argc)
 {
-	int		fd;
+	// int		fd;
 	t_mlx	mlx;
 
-	fd = fd_get(argv, argc);
-	info_get(fd);
-
+	// fd = fd_get(argv, argc);
+	// info_get(fd);
+	(void)argv;
+	(void)argc;
 	program_init(&mlx);
 	scene_draw(&mlx);
-
-	mlx.mlx = mlx_init();
-	mlx.win = mlx_new_window(mlx.mlx, 1920, 1080, "miniRT");
-
 	mlx_hook(mlx.win, X11_KEYPRESS, 1L << 0, key_press, &mlx);
 	mlx_hook(mlx.win, X11_CLOSEBTN, 1L << 2, exit_button, &mlx);
 	mlx_loop(mlx.mlx);

--- a/src/scene/object.c
+++ b/src/scene/object.c
@@ -1,0 +1,34 @@
+#include "scene.h"
+#include "libft.h"
+
+t_obj_list	*new_object(t_obj_type type, void *object, t_color3 color)
+{
+	t_obj_list	*new;
+
+	new = ft_calloc(sizeof(t_obj_list), 0);
+	new->type = type;
+	new->color = color;
+	new->object = object;
+	return (new);
+}
+
+t_light	*new_point_light(t_point3 light_origin, double bright_ratio)
+{
+	t_light	*light;
+
+	light = ft_calloc(sizeof(t_light), 0);
+	light->origin = light_origin;
+	light->bright_ratio = bright_ratio;
+	return (light);
+}
+
+t_sphere	*new_sphere(t_point3 center, double radius)
+{
+	t_sphere	*sp;
+
+	sp = ft_calloc(sizeof(t_sphere), 0);
+	sp->center = center;
+	sp->radius = radius;
+	sp->radius2 = radius * radius;
+	return (sp);
+}

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -2,14 +2,26 @@
 #include "scene.h"
 #include "vector3.h"
 #include "libft.h"
+#include "list.h"
 
 t_scene	*new_scene(int width, int height)
 {
-	t_scene	*scene;
+	t_scene		*scene;
+	t_obj_list	*objects;
+	t_obj_list	*lights;
 
 	scene = ft_calloc(sizeof(t_scene), 0);
 	scene->canvas = canvas_set(width, height);
-	scene->camera = camera_set(&scene->canvas, point3(0, 0, 0), vec3_unit(vec3(0, 0, -1)), 90);
+	scene->camera = camera_set(&scene->canvas, point3(-2, 2, 1), vec3_unit(vec3(-2, 2, 2)), 90);
+	objects = new_object(SPHERE, new_sphere(point3(0.0, -100.5, -1.0), 100), color3(0.8, 0.8, 0));
+	obj_list_add_back(&objects, new_object(SPHERE, new_sphere(point3(0, 0, -1.0), 0.5), color3(0.1, 0.2, 0.5)));
+	obj_list_add_back(&objects, new_object(SPHERE, new_sphere(point3(-1, 0, -1.0), 0.5), color3(0.8, 0.8, 0.1)));
+	obj_list_add_back(&objects, new_object(SPHERE, new_sphere(point3(1, 0, -1.0), 0.5), color3(0.8, 0.6, 0.2)));
+	scene->objects = objects;
+	lights = new_object(POINT_LIGHT, new_point_light(point3(0, 20, 0), 0.6), color3(1, 1, 1));
+	scene->lights = lights;
+	scene->ambient.light_color = color3(1, 1, 1);
+	scene->ambient.light_ratio = 0.1;
 	return (scene);
 }
 

--- a/src/trace/hit.c
+++ b/src/trace/hit.c
@@ -1,0 +1,37 @@
+#include "trace.h"
+
+t_bool	hit(t_obj_list objects[], t_ray *ray, t_hit_record *record)
+{
+	t_bool			hit_anything;
+	t_hit_record	temp_record;
+
+	temp_record = *record;
+	hit_anything = FALSE;
+	while (objects)
+	{
+		if (object_hit(objects, ray, &temp_record))
+		{
+			hit_anything = TRUE;
+			temp_record.tmax = temp_record.t;
+			*record = temp_record;
+		}
+		objects = objects->next;
+	}
+	return (hit_anything);
+}
+
+static t_obj_hit_f	object_type_check(t_obj_list object)
+{
+	if (object.type == SPHERE)
+		return (hit_sphere);
+	return (0);
+}
+
+t_bool	object_hit(t_obj_list objects[], t_ray *ray, t_hit_record *record)
+{
+	t_bool				hit_result;
+	const t_obj_hit_f	object_hit = object_type_check(*objects);
+
+	hit_result = FALSE | object_hit(objects, ray, record);
+	return (hit_result);
+}

--- a/src/trace/hit_sphere.c
+++ b/src/trace/hit_sphere.c
@@ -1,0 +1,40 @@
+#include <math.h>
+#include "trace.h"
+#include "vector3.h"
+
+t_bool	hit_sphere(t_obj_list objects[], t_ray *ray, t_hit_record *rec)
+{
+	t_vec3		oc;
+	double		a;
+	double		half_b;
+	double		c;
+	double		discriminant;
+	double		sqrt_d;
+	double		root;
+	t_sphere	*sp;
+
+	sp = (t_sphere *)objects->object;
+
+	oc = vec3_minus(ray->origin, sp->center);
+	a = vec3_length_square(ray->direction);
+	half_b = vec3_dot(ray->direction, oc);
+	c = vec3_length_square(oc) - sp->radius2;
+	discriminant = half_b * half_b - a * c;
+
+	if (discriminant < 0)
+		return (FALSE);
+	sqrt_d = sqrt(discriminant);
+	root = (half_b * (-1) - sqrt_d) / a;
+	if (root < rec->tmin || rec->tmax < root)
+	{
+		root = (half_b * (-1) + sqrt_d) / a;
+		if (root < rec->tmin || rec->tmax < root)
+			return (FALSE);
+	}
+	rec->t = root;
+	rec->p = ray_at(ray, root);
+	rec->normal = vec3_unit(vec3_minus(rec->p, sp->center));
+	rec->color = objects->color;
+	// set_face_normal(ray, rec);
+	return (TRUE);
+}

--- a/src/trace/phong_illumination.c
+++ b/src/trace/phong_illumination.c
@@ -1,0 +1,40 @@
+#include "trace.h"
+#include "vector3.h"
+
+t_color3	phong_illumination_model(t_scene *scene)
+{
+	t_color3	ambient_color;
+	t_color3	result_color;
+	t_obj_list	*light;
+
+	result_color = color3(0, 0, 0);
+	light = scene->lights;
+	while (light)
+	{
+		if (light->type == POINT_LIGHT)
+			result_color = vec3_plus(
+					result_color, point_light_get(scene, light));
+		light = light->next;
+	}
+	ambient_color = vec3_mult_scalar(scene->ambient.light_color,
+			scene->ambient.light_ratio);
+	result_color = vec3_plus(result_color, ambient_color);
+	return (vec3_min(color3(1, 1, 1),
+			vec3_mult(result_color, scene->record.color)));
+}
+
+t_color3	point_light_get(t_scene *scene, t_obj_list *light)
+{
+	t_light	*light_data;
+	t_vec3	light_dir;
+	t_vec3	phong_color;
+
+	light_data = (t_light *)light->object;
+	light_dir = vec3_minus(light_data->origin, scene->record.p);
+	if (is_in_shadow(scene, light_dir))
+		return (color3(0, 0, 0));
+	light_dir = vec3_unit(light_dir);
+	phong_color = vec3_plus(phong_diffuse(scene, light, light_dir),
+			phong_specular(scene, light, light_dir));
+	return (vec3_mult_scalar(phong_color, light_data->bright_ratio));
+}

--- a/src/trace/phong_light.c
+++ b/src/trace/phong_light.c
@@ -1,0 +1,51 @@
+#include <math.h>
+#include "trace.h"
+#include "vector3.h"
+
+/*	Id = Ld * kd * (n·l)
+	ex) kd = 1
+*/
+t_color3	phong_diffuse(t_scene *scene, t_obj_list *light, t_vec3 light_dir)
+{
+	double		kd;
+
+	kd = fmax(0.0, vec3_dot(scene->record.normal, light_dir));
+	return (vec3_mult_scalar(light->color, kd));
+}
+
+//	r = 2(n·l)n - l
+static t_vec3	reflect(t_vec3 l, t_vec3 n)
+{
+	return (vec3_minus(vec3_mult_scalar(n, vec3_dot(n, l) * 2), l));
+}
+
+/*	Is = Ls * ks * (r·v)^ksn
+	ex) ks = 0.5, ksn = 64
+*/
+t_color3	phong_specular(t_scene *scene, t_obj_list *light, t_vec3 light_dir)
+{
+	t_vec3			view_dir;
+	t_vec3			reflect_dir;
+	double			spec;
+	const double	ksn = 64;
+	const double	ks = 0.5;
+
+	view_dir = vec3_unit(vec3_mult_scalar(scene->ray.direction, -1));
+	reflect_dir = reflect(light_dir, scene->record.normal);
+	spec = pow(fmax(0.0, vec3_dot(reflect_dir, view_dir)), ksn);
+	return (vec3_mult_scalar(vec3_mult_scalar(light->color, ks), spec));
+}
+
+t_bool	is_in_shadow(t_scene *scene, t_vec3 light_dir)
+{
+	t_ray			shadow_ray;
+	t_hit_record	record;
+
+	shadow_ray = ray_set(vec3_plus(scene->record.p,
+				vec3_mult_scalar(light_dir, EPSILON)), light_dir);
+	record.tmin = 0;
+	record.tmax = vec3_length(light_dir);
+	if (hit(scene->objects, &shadow_ray, &record))
+		return (TRUE);
+	return (FALSE);
+}

--- a/src/trace/ray.c
+++ b/src/trace/ray.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "trace.h"
 #include "vector3.h"
 
@@ -10,6 +11,7 @@ t_ray	ray_set(t_point3 origin, t_vec3 direction)
 	return (ray);
 }
 
+// d = LB + ⍺ * u + β * v + e
 t_ray	ray_primary(t_camera *cam, double alpha, double beta)
 {
 	t_ray	ray;
@@ -21,11 +23,35 @@ t_ray	ray_primary(t_camera *cam, double alpha, double beta)
 	return (ray);
 }
 
-t_color3	ray_color(t_scene *scene)
+//	p = e + td
+t_point3	ray_at(t_ray *ray, double t)
+{
+	t_point3	at;
+
+	at = vec3_plus(ray->origin, vec3_mult_scalar(ray->direction, t));
+	return (at);
+}
+
+static t_hit_record	record_init(void)
+{
+	t_hit_record	record;
+
+	record.tmin = EPSILON;
+	record.tmax = INFINITY;
+	return (record);
+}
+
+t_color3	ray_tracing(t_scene *scene)
 {
 	double	t;
 
-	t = 0.5 * (scene->ray.direction.y + 1.0);
-	return (vec3_plus(vec3_mult_scalar(color3(1, 1, 1), 1.0 - t),
-			vec3_mult_scalar(color3(0.5, 0.7, 1.0), t)));
+	scene->record = record_init();
+	if (hit(scene->objects, &scene->ray, &scene->record))
+		return (phong_illumination_model(scene));
+	else
+	{	
+		t = 0.5 * (scene->ray.direction.y + 1.0);
+		return (vec3_plus(vec3_mult_scalar(color3(1, 1, 1), 1.0 - t),
+				vec3_mult_scalar(color3(0.5, 0.7, 1.0), t)));
+	}
 }


### PR DESCRIPTION
### 개요
구에 대한 ray tracing과 phong illumination model, hard shadow 적용
- tutorial 코드에서 일부 함수 이름 변경 + 함수포인터 사용
- 불가피한 케이스 제외하고 norm 확인 완료
- leaks 확인 완료

### 폴더 구성
```c
🗂 scene
⎿ object.c: object 리스트, 점광원, 구 생성하는 함수
⎿ scene.c: parser 전에는 수동으로 object 추가할 수 있도록 설정

🗂 trace
⎿ hit_sphere.c: 구와의 교점 판별
⎿ hit.c: object들과의 교점 판별
⎿ phong_illumination.c: ambient와 최종 color 계산
⎿ phong_light.c: diffuse, specular, hard shadow 계산 함수
⎿ ray.c: ray_color -> ray_tracing으로 이름 변경
```

### 결과
![image](https://user-images.githubusercontent.com/76509884/159919506-11f63a13-4efe-4e56-8e83-094cfb912652.png)


- #19 

### 앞으로 할 일
- hit_sphere() 함수 리팩토링 예정 (새로운 issue로 추가 할 예정)
- plane, cylinder 추가 예정