### PR TITLE
fix: :lipstick: Fix finding out of range and allowing property.

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -29,7 +29,7 @@ t_parse			*del_split(char **str);
 // parse_bool
 
 t_bool			is_scene_env_valid(t_parse_list *lst);
-t_bool			is_element_valid(char **str, int idx);
 t_bool			is_info_valid(t_obj_type id, t_info info);
+t_bool			is_element_valid(t_obj_type id, char **str);
 
 #endif

--- a/src/parse/parse_bool.c
+++ b/src/parse/parse_bool.c
@@ -27,18 +27,6 @@ t_bool	is_scene_env_valid(t_parse_list *lst)
 	return (FALSE);
 }
 
-t_bool	is_element_valid(char **str, int idx)
-{
-	int		i;
-
-	i = 0;
-	while (str[i] != NULL)
-		++i;
-	if (i != idx)
-		return (FALSE);
-	return (TRUE);
-}
-
 t_bool	is_info_valid(t_obj_type id, t_info info)
 {
 	if (info == POINT && \
@@ -60,4 +48,32 @@ t_bool	is_info_valid(t_obj_type id, t_info info)
 	id == CYLINDER))
 		return (TRUE);
 	return (FALSE);
+}
+
+t_bool	is_element_valid(t_obj_type id, char **str)
+{
+	int		i;
+	int		idx;
+
+	i = 0;
+	idx = 1;
+	if (is_info_valid(id, POINT))
+		++idx;
+	if (is_info_valid(id, BRI_RATIO))
+		++idx;
+	if (is_info_valid(id, NOR_VEC))
+		++idx;
+	if (is_info_valid(id, DIAMETER))
+		++idx;
+	if (is_info_valid(id, HEIGHT))
+		++idx;
+	if (is_info_valid(id, FOV))
+		++idx;
+	if (is_info_valid(id, RGB))
+		++idx;
+	while (str[i] != NULL)
+		++i;
+	if (i != idx)
+		return (FALSE);
+	return (TRUE);
 }

--- a/src/parse/parse_to_num.c
+++ b/src/parse/parse_to_num.c
@@ -2,6 +2,7 @@
 #include "libft.h"
 #include "vector3.h"
 #include "error.h"
+#include <math.h>
 
 double	double_get(char *s, double min, double max)
 {
@@ -13,6 +14,8 @@ double	double_get(char *s, double min, double max)
 		error_user("Elements must came in standard.\n");
 	if (min == 0 && max == 0)
 		return (d);
+	else if (min == 0 && max == INFINITY && d < 0)
+		error_user("The properties of the shape must be positive.\n");
 	if (d < min || d > max)
 		error_user("Elements must came in standard.\n");
 	return (d);

--- a/src/parse/parse_to_str.c
+++ b/src/parse/parse_to_str.c
@@ -26,11 +26,13 @@ static void	parse_set(t_parse *lst, char **str)
 {
 	int		idx;
 
+	idx = 1;
 	lst->ident = str[0];
 	lst->id = element_type_get(str[0]);
 	if (lst->id == NOTTYPE)
 		error_user("invalid element name.\n");
-	idx = 1;
+	if (is_element_valid(lst->id, str) == FALSE)
+		error_user("Elements came in more than standard.\n");
 	if (is_info_valid(lst->id, POINT))
 		lst->point = str[idx++];
 	if (is_info_valid(lst->id, BRI_RATIO))
@@ -45,8 +47,6 @@ static void	parse_set(t_parse *lst, char **str)
 		lst->fov = str[idx++];
 	if (is_info_valid(lst->id, RGB))
 		lst->rgb = str[idx++];
-	if (is_element_valid(str, idx) == 0)
-		error_user("Elements came in more than standard.\n");
 }
 
 static t_parse	*element_set(char *line)

--- a/src/scene/objects.c
+++ b/src/scene/objects.c
@@ -2,6 +2,7 @@
 #include "parse.h"
 #include "scene.h"
 #include "list.h"
+#include <math.h>
 
 void	sphere_set(t_scene *scene, t_parse_list *lst)
 {
@@ -14,7 +15,7 @@ void	sphere_set(t_scene *scene, t_parse_list *lst)
 	sphere = ft_calloc(sizeof(t_sphere), 0);
 	obj_list_add_back(&scene->objects, lst_new);
 	sphere->center = vec_get(lst_parse->point, 0, 0);
-	sphere->radius = double_get(lst_parse->diameter, 0, 0) / 2;
+	sphere->radius = double_get(lst_parse->diameter, 0, INFINITY) / 2;
 	sphere->radius2 = sphere->radius * sphere->radius;
 	lst_new->type = SPHERE;
 	lst_new->color = vec_get(lst_parse->rgb, 0, 255);
@@ -50,9 +51,9 @@ void	cylinder_set(t_scene *scene, t_parse_list *lst)
 	obj_list_add_back(&scene->objects, lst_new);
 	cylinder->center = vec_get(lst_parse->point, 0, 0);
 	cylinder->normal = vec_get(lst_parse->nor_vec, -1, 1);
-	cylinder->radius = double_get(lst_parse->diameter, 0, 0) / 2;
+	cylinder->radius = double_get(lst_parse->diameter, 0, INFINITY) / 2;
 	cylinder->radius2 = cylinder->radius * cylinder->radius;
-	cylinder->height = double_get(lst_parse->height, 0, 0);
+	cylinder->height = double_get(lst_parse->height, 0, INFINITY);
 	lst_new->type = CYLINDER;
 	lst_new->color = vec_get(lst_parse->rgb, 0, 255);
 	lst_new->object = cylinder;


### PR DESCRIPTION
[ 수정 부분 ]
1. split 이후에 문자열을 탐색하는 과정에서 split된 size 이후로도 탐색하는 문제 해결 (= 인자가 더 적게 들어왔을 때의 문제)
2. 구나 실린더의 지름, 높이와 같은 특성이 음수인 경우 예외처리

Mandatory ver2

- closes #51