### PR TITLE
feat: :sparkles: Add light parse more than one

### DIFF
--- a/src_bonus/parse/parse_bool_bonus.c
+++ b/src_bonus/parse/parse_bool_bonus.c
@@ -22,7 +22,7 @@ t_bool	is_scene_env_valid(t_parse_list *lst)
 			++camera_num;
 		lst = lst->next;
 	}
-	if (ambient_num == 1 && light_num == 1 && camera_num == 1)
+	if (ambient_num == 1 && light_num >= 1 && camera_num == 1)
 		return (TRUE);
 	return (FALSE);
 }

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -125,6 +125,7 @@ t_obj_list	*parse_to_str(int fd)
 			free(line);
 	}
 	if (is_scene_env_valid(lst_head) == FALSE)
-		error_user("Each Ambient, Light and Camera must be one.");
+		error_user("Each Ambient and Camera must be one, \
+Light must be more than one.");
 	return (lst_head);
 }

--- a/src_bonus/trace/hit_cone_bonus.c
+++ b/src_bonus/trace/hit_cone_bonus.c
@@ -16,7 +16,6 @@ static void	cone_uv(t_hit_record *rec, t_object *co, double *u, double *v)
 	v_dir = vec3_unit(v_dir);
 	u_dir = vec3_unit(vec3_cross(v_dir, co->normal));
 	pc = vec3_minus(rec->p, co->center);
-
 	theta = atan2(-1 * vec3_dot(pc, v_dir), vec3_dot(pc, u_dir)) + M_PI;
 	height = vec3_dot(pc, co->normal);
 	*u = theta * M_1_PI * 0.5;


### PR DESCRIPTION
빛 여러개 받기 가능하게끔 함수 수정했습니다.
```
...
L 20,20,20  0.6  5,255,255
L 0,20,0    0.6  255,255,255
...
```
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/63245869/162554973-d348c2c9-0529-4f09-ad64-81771a55b0b6.png">

빛 인자값은 그대로 L로 받는걸로 했습니다.
cone norminette 수정도 끼워넣었습니다 ..ㅎㅎ
- closes #65