### PR TITLE
fix: :bug: Fix if directory end [.rt]

### DIFF
--- a/lib/libft/include/ft_read.h
+++ b/lib/libft/include/ft_read.h
@@ -8,6 +8,6 @@
 #  define FD_MAX 256
 # endif
 
-int		get_next_line(int fd, char **line);
+t_gnl_res		get_next_line(int fd, char **line);
 
 #endif

--- a/lib/libft/include/libft_type.h
+++ b/lib/libft/include/libft_type.h
@@ -14,4 +14,12 @@ typedef enum e_res
 	ERR = -2,
 }	t_res;
 
+typedef enum e_gnl_res
+{
+	READFAIL = -2,
+	ERROR = -1,
+	FIN = 0,
+	SUCCESS = 1,
+}	t_gnl_res;
+
 #endif

--- a/lib/libft/src/read/get_next_line.c
+++ b/lib/libft/src/read/get_next_line.c
@@ -42,27 +42,27 @@ char **buffer)
 	return (1);
 }
 
-static int	free_buffer(char **buffer, int i)
+static t_gnl_res	free_buffer(char **buffer, t_gnl_res res)
 {
 	free(*buffer);
-	return (i);
+	return (res);
 }
 
 static int	read_fin(char **buffer, char **line_tmp, char **line, \
 int read_num)
 {
 	if (read_num < 0)
-		return (free_buffer(buffer, -2));
+		return (free_buffer(buffer, READFAIL));
 	else
 	{
 		if (*line_tmp)
-			return (free_buffer(buffer, 0));
+			return (free_buffer(buffer, FIN));
 		*line = ft_strdup("");
-		return (free_buffer(buffer, 0));
+		return (free_buffer(buffer, FIN));
 	}
 }
 
-int	get_next_line(int fd, char **line)
+t_gnl_res	get_next_line(int fd, char **line)
 {
 	static char		*line_save[FD_MAX + 1];
 	char			*buffer;
@@ -70,12 +70,12 @@ int	get_next_line(int fd, char **line)
 	int				read_num;
 
 	if (fd < 0 || fd > FD_MAX || BUFFER_SIZE <= 0 || !line)
-		return (-1);
+		return (ERROR);
 	buffer = ft_calloc(sizeof(char), BUFFER_SIZE);
 	line_tmp = line_save[fd];
 	if (line_save[fd])
 		if (!(make_line(line, &line_save[fd], &line_tmp, NULL)))
-			return (free_buffer(&buffer, -1));
+			return (free_buffer(&buffer, ERROR));
 	while (!line_save[fd])
 	{
 		read_num = read(fd, buffer, BUFFER_SIZE);
@@ -83,7 +83,7 @@ int	get_next_line(int fd, char **line)
 			return (read_fin(&buffer, &line_tmp, line, read_num));
 		buffer[read_num] = '\0';
 		if (!(make_line(line, &line_save[fd], &line_tmp, &buffer)))
-			return (free_buffer(&buffer, -1));
+			return (free_buffer(&buffer, ERROR));
 	}
-	return (free_buffer(&buffer, 1));
+	return (free_buffer(&buffer, SUCCESS));
 }

--- a/lib/libft/src/read/get_next_line.c
+++ b/lib/libft/src/read/get_next_line.c
@@ -12,8 +12,6 @@ static int	tok_line(char *s, char **next)
 	{
 		*s++ = '\0';
 		*next = ft_strdup(s);
-		if (!(*next))
-			return (0);
 		return (1);
 	}
 	else
@@ -31,16 +29,12 @@ char **buffer)
 		if (!(tok_line(*buffer, line_save)))
 			return (0);
 		*line = ft_strjoin(*line_tmp, *buffer);
-		if (!(*line))
-			return (0);
 	}
 	else
 	{
 		if (!(tok_line(*line_save, line_save)))
 			return (0);
 		*line = ft_strdup(*line_tmp);
-		if (!(*line))
-			return (0);
 	}
 	if (*line_tmp)
 		free(*line_tmp);
@@ -58,16 +52,13 @@ static int	read_fin(char **buffer, char **line_tmp, char **line, \
 int read_num)
 {
 	if (read_num < 0)
-		return (free_buffer(buffer, -1));
+		return (free_buffer(buffer, -2));
 	else
 	{
 		if (*line_tmp)
 			return (free_buffer(buffer, 0));
 		*line = ft_strdup("");
-		if (!(*line))
-			return (free_buffer(buffer, -1));
-		else
-			return (free_buffer(buffer, 0));
+		return (free_buffer(buffer, 0));
 	}
 }
 
@@ -80,9 +71,7 @@ int	get_next_line(int fd, char **line)
 
 	if (fd < 0 || fd > FD_MAX || BUFFER_SIZE <= 0 || !line)
 		return (-1);
-	buffer = (char *)malloc(BUFFER_SIZE + 1);
-	if (!buffer)
-		return (-1);
+	buffer = ft_calloc(sizeof(char), BUFFER_SIZE);
 	line_tmp = line_save[fd];
 	if (line_save[fd])
 		if (!(make_line(line, &line_save[fd], &line_tmp, NULL)))

--- a/lib/libft/src/string/ft_strdup.c
+++ b/lib/libft/src/string/ft_strdup.c
@@ -11,9 +11,7 @@ char	*ft_strdup(const char *s1)
 	len = 0;
 	while (s1[len])
 		len++;
-	cp = (char *)malloc(len + 1);
-	if (!cp)
-		return (NULL);
+	cp = ft_calloc(sizeof(char), len);
 	while (i < len + 1)
 	{
 		cp[i] = s1[i];

--- a/lib/libft/src/string/ft_strjoin.c
+++ b/lib/libft/src/string/ft_strjoin.c
@@ -16,9 +16,7 @@ char	*ft_strjoin(char const *s1, char const *s2)
 		return (ft_strdup(s1));
 	len[0] = ft_strlen(s1);
 	len[1] = ft_strlen(s2);
-	s1s2 = (char *)malloc(len[0] + len[1] + 1);
-	if (!s1s2)
-		return (NULL);
+	s1s2 = ft_calloc(sizeof(char), len[0] + len[1]);
 	while (*s1)
 		s1s2[i++] = *s1++;
 	while (*s2)

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -105,18 +105,18 @@ static t_parse	*element_set(char *line)
 t_obj_list	*parse_to_str(int fd)
 {
 	char		*line;
-	int			gnl_ret;
+	t_gnl_res	gnl_ret;
 	t_obj_list	*lst_head;
 	t_parse		*lst_parse;
 
-	gnl_ret = 1;
+	gnl_ret = SUCCESS;
 	lst_head = NULL;
-	while (gnl_ret == 1)
+	while (gnl_ret == SUCCESS)
 	{
 		gnl_ret = get_next_line(fd, &line);
-		if (gnl_ret == -1)
-			error_user("get_next_line - dynamic allocation problem.\n");
-		else if (gnl_ret == -2)
+		if (gnl_ret == ERROR)
+			error_user("get_next_line error.\n");
+		else if (gnl_ret == READFAIL)
 			error_user("File format dose not match.\n");
 		lst_parse = element_set(line);
 		if (lst_parse != NULL)

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -108,9 +108,7 @@ t_obj_list	*parse_to_str(int fd)
 	int			gnl_ret;
 	t_obj_list	*lst_head;
 	t_parse		*lst_parse;
-	t_color3	color;
 
-	color = color3(0, 0, 0);
 	gnl_ret = 1;
 	lst_head = NULL;
 	while (gnl_ret == 1)
@@ -118,9 +116,12 @@ t_obj_list	*parse_to_str(int fd)
 		gnl_ret = get_next_line(fd, &line);
 		if (gnl_ret == -1)
 			error_user("get_next_line - dynamic allocation problem.\n");
+		else if (gnl_ret == -2)
+			error_user("File format dose not match.\n");
 		lst_parse = element_set(line);
 		if (lst_parse != NULL)
-			obj_list_add_back(&lst_head, new_obj_list(lst_parse, 0, color));
+			obj_list_add_back(&lst_head, \
+			new_obj_list(lst_parse, 0, color3(0, 0, 0)));
 		if (line != NULL)
 			free(line);
 	}


### PR DESCRIPTION
폴더명이 .rt로 끝날 때에 대한 에러 메세지 수정

- 빈 파일
<img width="474" alt="image" src="https://user-images.githubusercontent.com/63245869/162556568-acb08004-748a-4372-a8f4-563f5b090257.png">

- 폴더
<img width="447" alt="image" src="https://user-images.githubusercontent.com/63245869/162556551-e5cfecce-8731-4450-b268-723bac279105.png">

- gnl 리턴값
<img width="196" alt="image" src="https://user-images.githubusercontent.com/63245869/162557488-d8f88154-e595-4359-a988-8c8b585db958.png">

- gnl, ft_strdup, ft_strjoin에서 malloc을 ft_calloc으로 수정
- gnl받는 함수 parse_to_str에서 ReadFail시 예외사항 추가

- closes #58