### PR TITLE
Cjang/issue69 add texture only

### DIFF
--- a/include_bonus/structure_bonus.h
+++ b/include_bonus/structure_bonus.h
@@ -119,8 +119,8 @@ typedef struct s_checkboard
 
 typedef struct s_bumpmap
 {
-	t_xpm_image	texture;
-	t_xpm_image	bump;
+	t_xpm_image	*texture;
+	t_xpm_image	*bump;
 }	t_bumpmap;
 
 typedef struct s_color_info

--- a/include_bonus/trace_bonus.h
+++ b/include_bonus/trace_bonus.h
@@ -42,7 +42,7 @@ t_bool		is_checkerboard(t_color_info texture);
 t_bool		is_bumpmap(t_color_info texture);
 t_color3	checker_color(double u, double v, t_color_info color);
 
-t_color3	image_mapping(double u, double v, t_xpm_image img);
-t_vec3		normal_mapping(t_hit_record *rec, t_xpm_image img);
+t_color3	image_mapping(double u, double v, t_xpm_image *img);
+t_vec3		normal_mapping(t_hit_record *rec, t_xpm_image *img);
 
 #endif

--- a/src_bonus/list/list_del_bonus.c
+++ b/src_bonus/list/list_del_bonus.c
@@ -8,10 +8,18 @@ void	del_color(t_color_info color)
 		free(color.checkboard);
 	if (color.bumpmap != NULL)
 	{
-		if (color.bumpmap->texture.data.img != NULL)
-			free(color.bumpmap->texture.data.img);
-		if (color.bumpmap->bump.data.img != NULL)
-			free(color.bumpmap->bump.data.img);
+		if (color.bumpmap->texture != NULL)
+		{
+			if (color.bumpmap->texture->data.img != NULL)
+				free(color.bumpmap->texture->data.img);
+			free(color.bumpmap->texture);
+		}
+		if (color.bumpmap->bump != NULL)
+		{
+			if (color.bumpmap->bump->data.img != NULL)
+				free(color.bumpmap->bump->data.img);
+			free(color.bumpmap->bump);
+		}
 		free(color.bumpmap);
 	}
 }

--- a/src_bonus/parse/parse_bool_bonus.c
+++ b/src_bonus/parse/parse_bool_bonus.c
@@ -90,7 +90,7 @@ t_bool	is_texture_valid(t_color_type id, char **str, int idx)
 		return (FALSE);
 	if (id == CHECKBOARD && i - idx == 4)
 		return (TRUE);
-	else if (id == BUMPMAP && i - idx == 3)
+	else if (id == BUMPMAP && (i - idx == 2 || i - idx == 3))
 		return (TRUE);
 	return (FALSE);
 }

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -74,11 +74,10 @@ static void	parse_bonus_set(t_parse *lst, char **str, int idx)
 		lst->check_width = str[++idx];
 		lst->check_height = str[++idx];
 	}
-	else if (lst->texture_id == BUMPMAP)
-	{
+	if (lst->texture_id == BUMPMAP)
 		lst->texture_file = str[++idx];
-		lst->bump_file = str[++idx];
-	}
+	if (lst->texture_id == BUMPMAP && str[++idx] != NULL)
+		lst->bump_file = str[idx];
 }
 
 static t_parse	*element_set(char *line)

--- a/src_bonus/scene/objects_bonus.c
+++ b/src_bonus/scene/objects_bonus.c
@@ -6,13 +6,14 @@
 #include "list_bonus.h"
 #include <math.h>
 
-static t_xpm_image	image_get(char *filename, void *mlx_ptr)
+static t_xpm_image	*image_get(char *filename, void *mlx_ptr)
 {
-	t_xpm_image	image;
+	t_xpm_image	*image;
 	char		*extension_name;
 	int			filename_len;
 	int			cmp_num;
 
+	image = ft_calloc(sizeof(t_xpm_image), 0);
 	extension_name = ".xpm";
 	filename_len = ft_strlen(filename);
 	if (filename_len < 4)
@@ -20,12 +21,12 @@ static t_xpm_image	image_get(char *filename, void *mlx_ptr)
 	cmp_num = ft_strcmp(&filename[filename_len - 4], extension_name);
 	if (cmp_num != 0)
 		error_user("The image file extension must be [.xpm].\n");
-	image.data.img = mlx_xpm_file_to_image(mlx_ptr, \
-	filename, &image.width, &image.height);
-	if (image.data.img == NULL)
+	image->data.img = mlx_xpm_file_to_image(mlx_ptr, \
+	filename, &image->width, &image->height);
+	if (image->data.img == NULL)
 		error_user("image file is not correct.\n");
-	image.data.addr = mlx_get_data_addr(image.data.img, \
-	&image.data.bpp, &image.data.line, &image.data.endian);
+	image->data.addr = mlx_get_data_addr(image->data.img, \
+	&image->data.bpp, &image->data.line, &image->data.endian);
 	return (image);
 }
 
@@ -44,7 +45,8 @@ static void	texture_get(t_obj_list *l, t_parse *p, void *mlx_ptr)
 	{
 		l->color.bumpmap = ft_calloc(sizeof(t_bumpmap), 0);
 		l->color.bumpmap->texture = image_get(p->texture_file, mlx_ptr);
-		l->color.bumpmap->bump = image_get(p->bump_file, mlx_ptr);
+		if (p->bump_file != NULL)
+			l->color.bumpmap->bump = image_get(p->bump_file, mlx_ptr);
 	}
 }
 

--- a/src_bonus/trace/image_mapping_bonus.c
+++ b/src_bonus/trace/image_mapping_bonus.c
@@ -19,28 +19,28 @@ static t_color3	pixel_to_color3(int mlx_color)
 	return (color3(r, g, b));
 }
 
-t_color3	image_mapping(double u, double v, t_xpm_image img)
+t_color3	image_mapping(double u, double v, t_xpm_image *img)
 {
 	int		u_int;
 	int		v_int;
 	int		mlx_color;
 
-	u_int = (int)(u * img.width);
-	v_int = (int)((1.0 - v) * img.height);
-	mlx_color = xpm_pixel_get(&img, u_int, v_int);
+	u_int = (int)(u * img->width);
+	v_int = (int)((1.0 - v) * img->height);
+	mlx_color = xpm_pixel_get(img, u_int, v_int);
 	return (pixel_to_color3(mlx_color));
 }
 
-t_vec3	normal_mapping(t_hit_record *rec, t_xpm_image img)
+t_vec3	normal_mapping(t_hit_record *rec, t_xpm_image *img)
 {
 	int		u_int;
 	int		v_int;
 	int		mlx_color;
 	t_vec3	normal_color;
 
-	u_int = (int)(rec->u * img.width);
-	v_int = (int)((1.0 - rec->v) * img.height);
-	mlx_color = xpm_pixel_get(&img, u_int, v_int);
+	u_int = (int)(rec->u * img->width);
+	v_int = (int)((1.0 - rec->v) * img->height);
+	mlx_color = xpm_pixel_get(img, u_int, v_int);
 	normal_color = pixel_to_color3(mlx_color);
 	normal_color = vec3_minus(vec3_mult_scalar(normal_color, 2), vec3(1, 1, 1));
 	return (vec3_unit(vec3(vec3_dot(rec->u_dir, normal_color),


### PR DESCRIPTION
- 기존 - bump map에서 인자는 texture, bump map 두개가 들어와야 함
- 변경 - texture만 들어와도 허용

<img width="198" alt="image" src="https://user-images.githubusercontent.com/63245869/162684187-ee18a596-25c1-4ca3-97a5-a2393673cb8a.png">

- 변경 상세내용
t_bumpmap 변수값의 수정, 그에 따른 함수 변경 및 할당 값 변경, del 함수 수정
image_mapping, normal_mapping 함수 인자 수정

- bump값이 들어왔는지 아닌지 유무 파악
t_bumppmap->bump == NULL 인지 아닌지를 통해


- closes #69