### PR TITLE
Cjang/issue76/object spec (오브젝트별 diffuse, specular 상수 추가)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ sceneB		:= ambient camera light objects scene
 traceB		:= hit_cone hit_cylinder hit_plane hit_sphere hit image_mapping \
 				phong_illumination phong_light ray texture util
 parseB		:= parse_bool parse_read parse_to_num parse_to_element \
-				parse_to_str parse_utils
+				parse_to_str parse_utils parse_str_set
 vector3B	:= vector_operation1 vector_operation2 vector_operation3 \
 				vector_set vector_matrix
 

--- a/include_bonus/parse_bonus.h
+++ b/include_bonus/parse_bonus.h
@@ -11,6 +11,12 @@ int				fd_get(int argv, char **argc);
 
 t_obj_list		*parse_to_str(int fd);
 
+// parse_str_set_bonus
+
+int				parse_set(t_parse *lst, char **str);
+int				parse_obj_spec_set(t_parse *lst, char **str, int idx);
+void			parse_texture_set(t_parse *lst, char **str, int idx);
+
 // parse_to_element
 
 t_scene			*parse_to_element(t_parse_list *lst, void *mlx_ptr);
@@ -33,6 +39,7 @@ int				split_len(char **str);
 t_bool			is_scene_env_valid(t_parse_list *lst);
 t_bool			is_info_valid(t_obj_type id, t_info info);
 t_bool			is_element_valid(t_obj_type id, char **str);
+t_bool			is_obj_spec_valid(t_obj_type id, char **str, int idx);
 t_bool			is_texture_valid(t_color_type id, char **str, int idx);
 
 #endif

--- a/include_bonus/structure_bonus.h
+++ b/include_bonus/structure_bonus.h
@@ -145,6 +145,18 @@ typedef struct s_obj_list
 	void			*next;
 }	t_obj_list;
 
+typedef struct s_object
+{
+	t_point3	center;
+	t_vec3		normal;
+	double		radius;
+	double		radius2;
+	double		height;
+	double		kd;
+	double		ks;
+	double		ksn;
+}	t_object;
+
 typedef struct s_canvas
 {
 	int		width;
@@ -184,6 +196,7 @@ typedef struct s_hit_record
 	double		v;
 	t_bool		front_face;
 	t_color3	color;
+	t_object	*obj;
 }	t_hit_record;
 
 typedef struct s_ambient
@@ -197,18 +210,6 @@ typedef struct s_light
 	t_point3	origin;
 	double		bright_ratio;
 }	t_light;
-
-typedef struct s_object
-{
-	t_point3	center;
-	t_vec3		normal;
-	double		radius;
-	double		radius2;
-	double		height;
-	double		kd;
-	double		ks;
-	double		ksn;
-}	t_object;
 
 typedef struct s_scene
 {

--- a/include_bonus/structure_bonus.h
+++ b/include_bonus/structure_bonus.h
@@ -82,6 +82,9 @@ typedef enum e_info
 	HEIGHT = 4,
 	FOV = 5,
 	RGB = 6,
+	KD = 7,
+	KS = 8,
+	KSN = 9,
 }	t_info;
 
 typedef enum e_color_mask
@@ -102,6 +105,9 @@ typedef struct s_parse
 	char			*height;
 	char			*fov;
 	char			*rgb;
+	char			*kd;
+	char			*ks;
+	char			*ksn;
 	t_color_type	texture_id;
 	char			*t_ident;
 	char			*check_color;
@@ -199,6 +205,9 @@ typedef struct s_object
 	double		radius;
 	double		radius2;
 	double		height;
+	double		kd;
+	double		ks;
+	double		ksn;
 }	t_object;
 
 typedef struct s_scene

--- a/src_bonus/parse/parse_bool_bonus.c
+++ b/src_bonus/parse/parse_bool_bonus.c
@@ -48,6 +48,9 @@ t_bool	is_info_valid(t_obj_type id, t_info info)
 	(id == AMBIENT || id == POINT_LIGHT || id == SPHERE || id == PLANE || \
 	id == CYLINDER || id == CONE))
 		return (TRUE);
+	else if ((info == KD || info == KS || info == KSN) && \
+	(id == SPHERE || id == PLANE || id == CYLINDER || id == CONE))
+		return (TRUE);
 	return (FALSE);
 }
 
@@ -58,20 +61,28 @@ t_bool	is_element_valid(t_obj_type id, char **str)
 
 	i = 0;
 	idx = 1;
-	if (is_info_valid(id, POINT))
-		++idx;
-	if (is_info_valid(id, BRI_RATIO))
-		++idx;
-	if (is_info_valid(id, NOR_VEC))
-		++idx;
-	if (is_info_valid(id, DIAMETER))
-		++idx;
-	if (is_info_valid(id, HEIGHT))
-		++idx;
-	if (is_info_valid(id, FOV))
-		++idx;
-	if (is_info_valid(id, RGB))
-		++idx;
+	idx += is_info_valid(id, POINT);
+	idx += is_info_valid(id, BRI_RATIO);
+	idx += is_info_valid(id, NOR_VEC);
+	idx += is_info_valid(id, DIAMETER);
+	idx += is_info_valid(id, HEIGHT);
+	idx += is_info_valid(id, FOV);
+	idx += is_info_valid(id, RGB);
+	while (str[i] != NULL)
+		++i;
+	if (i < idx)
+		return (FALSE);
+	return (TRUE);
+}
+
+t_bool	is_obj_spec_valid(t_obj_type id, char **str, int idx)
+{
+	int		i;
+
+	i = 0;
+	idx += is_info_valid(id, KD);
+	idx += is_info_valid(id, KS);
+	idx += is_info_valid(id, KSN);
 	while (str[i] != NULL)
 		++i;
 	if (i < idx)

--- a/src_bonus/parse/parse_str_set_bonus.c
+++ b/src_bonus/parse/parse_str_set_bonus.c
@@ -1,0 +1,92 @@
+#include "libft.h"
+#include "parse_bonus.h"
+#include "error_bonus.h"
+#include <stdlib.h>
+
+static t_obj_type	element_type_get(char *s)
+{
+	if (!ft_strcmp(s, "A"))
+		return (AMBIENT);
+	else if (!ft_strcmp(s, "C"))
+		return (CAMERA);
+	else if (!ft_strcmp(s, "L"))
+		return (POINT_LIGHT);
+	else if (!ft_strcmp(s, "sp"))
+		return (SPHERE);
+	else if (!ft_strcmp(s, "pl"))
+		return (PLANE);
+	else if (!ft_strcmp(s, "cy"))
+		return (CYLINDER);
+	else if (!ft_strcmp(s, "co"))
+		return (CONE);
+	return (NOTTYPE);
+}
+
+int	parse_set(t_parse *lst, char **str)
+{
+	int		idx;
+
+	idx = 1;
+	lst->ident = str[0];
+	lst->id = element_type_get(str[0]);
+	if (lst->id == NOTTYPE)
+		error_user("invalid element name.\n");
+	if (is_element_valid(lst->id, str) == FALSE)
+		error_user("Elements came in more than standard.\n");
+	if (is_info_valid(lst->id, POINT))
+		lst->point = str[idx++];
+	if (is_info_valid(lst->id, BRI_RATIO))
+		lst->bri_ratio = str[idx++];
+	if (is_info_valid(lst->id, NOR_VEC))
+		lst->nor_vec = str[idx++];
+	if (is_info_valid(lst->id, DIAMETER))
+		lst->diameter = str[idx++];
+	if (is_info_valid(lst->id, HEIGHT))
+		lst->height = str[idx++];
+	if (is_info_valid(lst->id, FOV))
+		lst->fov = str[idx++];
+	if (is_info_valid(lst->id, RGB))
+		lst->rgb = str[idx++];
+	return (idx);
+}
+
+int	parse_obj_spec_set(t_parse *lst, char **str, int idx)
+{
+	if (is_obj_spec_valid(lst->id, str, idx) == FALSE)
+		error_user("objecet spec came in wrong.\n");
+	if (is_info_valid(lst->id, KD))
+		lst->kd = str[idx++];
+	if (is_info_valid(lst->id, KS))
+		lst->ks = str[idx++];
+	if (is_info_valid(lst->id, KSN))
+		lst->ksn = str[idx++];
+	return (idx);
+}
+
+void	parse_texture_set(t_parse *lst, char **str, int idx)
+{
+	if (idx == split_len(str))
+	{
+		lst->texture_id = COLOR;
+		return ;
+	}
+	lst->t_ident = str[idx];
+	if (ft_strcmp(lst->t_ident, "ck") == 0)
+		lst->texture_id = CHECKBOARD;
+	else if (ft_strcmp(lst->t_ident, "bm") == 0)
+		lst->texture_id = BUMPMAP;
+	else
+		error_user("invalid texture name.\n");
+	if (is_texture_valid(lst->texture_id, str, idx) == FALSE)
+		error_user("texture info came in wrong.\n");
+	if (lst->texture_id == CHECKBOARD)
+	{
+		lst->check_color = str[++idx];
+		lst->check_width = str[++idx];
+		lst->check_height = str[++idx];
+	}
+	if (lst->texture_id == BUMPMAP)
+		lst->texture_file = str[++idx];
+	if (lst->texture_id == BUMPMAP && str[++idx] != NULL)
+		lst->bump_file = str[idx];
+}

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -5,81 +5,6 @@
 #include "error_bonus.h"
 #include <stdlib.h>
 
-static t_obj_type	element_type_get(char *s)
-{
-	if (!ft_strcmp(s, "A"))
-		return (AMBIENT);
-	else if (!ft_strcmp(s, "C"))
-		return (CAMERA);
-	else if (!ft_strcmp(s, "L"))
-		return (POINT_LIGHT);
-	else if (!ft_strcmp(s, "sp"))
-		return (SPHERE);
-	else if (!ft_strcmp(s, "pl"))
-		return (PLANE);
-	else if (!ft_strcmp(s, "cy"))
-		return (CYLINDER);
-	else if (!ft_strcmp(s, "co"))
-		return (CONE);
-	return (NOTTYPE);
-}
-
-static int	parse_set(t_parse *lst, char **str)
-{
-	int		idx;
-
-	idx = 1;
-	lst->ident = str[0];
-	lst->id = element_type_get(str[0]);
-	if (lst->id == NOTTYPE)
-		error_user("invalid element name.\n");
-	if (is_element_valid(lst->id, str) == FALSE)
-		error_user("Elements came in more than standard.\n");
-	if (is_info_valid(lst->id, POINT))
-		lst->point = str[idx++];
-	if (is_info_valid(lst->id, BRI_RATIO))
-		lst->bri_ratio = str[idx++];
-	if (is_info_valid(lst->id, NOR_VEC))
-		lst->nor_vec = str[idx++];
-	if (is_info_valid(lst->id, DIAMETER))
-		lst->diameter = str[idx++];
-	if (is_info_valid(lst->id, HEIGHT))
-		lst->height = str[idx++];
-	if (is_info_valid(lst->id, FOV))
-		lst->fov = str[idx++];
-	if (is_info_valid(lst->id, RGB))
-		lst->rgb = str[idx++];
-	return (idx);
-}
-
-static void	parse_bonus_set(t_parse *lst, char **str, int idx)
-{
-	if (idx == split_len(str))
-	{
-		lst->texture_id = COLOR;
-		return ;
-	}
-	lst->t_ident = str[idx];
-	if (ft_strcmp(lst->t_ident, "ck") == 0)
-		lst->texture_id = CHECKBOARD;
-	else if (ft_strcmp(lst->t_ident, "bm") == 0)
-		lst->texture_id = BUMPMAP;
-	else
-		error_user("invalid texture name.\n");
-	if (is_texture_valid(lst->texture_id, str, idx) == FALSE)
-		error_user("texture info came in wrong.\n");
-	if (lst->texture_id == CHECKBOARD)
-	{
-		lst->check_color = str[++idx];
-		lst->check_width = str[++idx];
-		lst->check_height = str[++idx];
-	}
-	if (lst->texture_id == BUMPMAP)
-		lst->texture_file = str[++idx];
-	if (lst->texture_id == BUMPMAP && str[++idx] != NULL)
-		lst->bump_file = str[idx];
-}
-
 static t_parse	*element_set(char *line)
 {
 	char		**str_splited;
@@ -96,7 +21,8 @@ static t_parse	*element_set(char *line)
 		return (del_split(str_splited));
 	}
 	idx = parse_set(lst, str_splited);
-	parse_bonus_set(lst, str_splited, idx);
+	idx = parse_obj_spec_set(lst, str_splited, idx);
+	parse_texture_set(lst, str_splited, idx);
 	free(str_splited);
 	return (lst);
 }

--- a/src_bonus/parse/parse_utils_bonus.c
+++ b/src_bonus/parse/parse_utils_bonus.c
@@ -28,6 +28,12 @@ void	del_parse(t_parse *parse)
 		free(parse->fov);
 	if (parse->rgb != NULL)
 		free(parse->rgb);
+	if (parse->kd != NULL)
+		free(parse->kd);
+	if (parse->ks != NULL)
+		free(parse->ks);
+	if (parse->ksn != NULL)
+		free(parse->ksn);
 }
 
 void	del_parse_texture(t_parse *parse)

--- a/src_bonus/scene/objects_bonus.c
+++ b/src_bonus/scene/objects_bonus.c
@@ -70,6 +70,9 @@ void	object_set(t_scene *scene, t_parse_list *lst, void *mlx_ptr)
 	}
 	if (lst_parse->id == CYLINDER || lst_parse->id == CONE)
 		object->height = double_get(lst_parse->height, 0, INFINITY);
+	object->kd = double_get(lst_parse->kd, 0, 1);
+	object->ks = double_get(lst_parse->ks, 0, 1);
+	object->ksn = double_get(lst_parse->ksn, 0, INFINITY);
 	lst_new->type = lst_parse->id;
 	lst_new->color.color = vec_get(lst_parse->rgb, 0, 255);
 	texture_get(lst_new, lst_parse, mlx_ptr);

--- a/src_bonus/trace/hit_cone_bonus.c
+++ b/src_bonus/trace/hit_cone_bonus.c
@@ -35,6 +35,7 @@ static t_bool	check_cone(
 	rec->normal = vec3_unit(vec3_minus(rec->p, vec3_plus(co->center,
 					vec3_mult_scalar(co->normal, vec3_dot(
 							vec3_minus(rec->p, co->center), co->normal)))));
+	rec->obj = co;
 	set_face_normal(ray, rec);
 	cone_uv(rec, co);
 	hit_color_set(rec, objects);

--- a/src_bonus/trace/hit_cylinder_bonus.c
+++ b/src_bonus/trace/hit_cylinder_bonus.c
@@ -35,6 +35,7 @@ static t_bool	check_cylinder(
 	rec->normal = vec3_unit(vec3_minus(rec->p, vec3_plus(cy->center,
 					vec3_mult_scalar(cy->normal, vec3_dot(
 							vec3_minus(rec->p, cy->center), cy->normal)))));
+	rec->obj = cy;
 	set_face_normal(ray, rec);
 	cylinder_uv(rec, cy);
 	hit_color_set(rec, objects);

--- a/src_bonus/trace/hit_plane_bonus.c
+++ b/src_bonus/trace/hit_plane_bonus.c
@@ -28,6 +28,7 @@ t_bool	hit_plane(t_obj_list objects[], t_ray *ray, t_hit_record *rec)
 	rec->t = root;
 	rec->p = ray_at(ray, root);
 	rec->normal = pl->normal;
+	rec->obj = pl;
 	set_face_normal(ray, rec);
 	plane_uv(rec);
 	hit_color_set(rec, objects);

--- a/src_bonus/trace/hit_sphere_bonus.c
+++ b/src_bonus/trace/hit_sphere_bonus.c
@@ -26,6 +26,7 @@ static t_bool	sphere_check(
 	rec->t = root;
 	rec->p = ray_at(ray, root);
 	rec->normal = vec3_unit(vec3_minus(rec->p, sp->center));
+	rec->obj = sp;
 	set_face_normal(ray, rec);
 	sphere_uv(rec);
 	hit_color_set(rec, objects);

--- a/src_bonus/trace/phong_light_bonus.c
+++ b/src_bonus/trace/phong_light_bonus.c
@@ -9,7 +9,8 @@ t_color3	phong_diffuse(t_scene *scene, t_obj_list *light, t_vec3 light_dir)
 {
 	double		kd;
 
-	kd = fmax(0.0, vec3_dot(scene->record.normal, light_dir));
+	kd = fmax(0.0, vec3_dot(scene->record.normal, light_dir)) * \
+	scene->record.obj->kd;
 	return (vec3_mult_scalar(light->color.color, kd));
 }
 
@@ -27,9 +28,11 @@ t_color3	phong_specular(t_scene *scene, t_obj_list *light, t_vec3 light_dir)
 	t_vec3			view_dir;
 	t_vec3			reflect_dir;
 	double			spec;
-	const double	ksn = 5;
-	const double	ks = 0.2;
+	double			ksn;
+	double			ks;
 
+	ksn = scene->record.obj->ksn;
+	ks = scene->record.obj->ks;
 	view_dir = vec3_unit(vec3_mult_scalar(scene->ray.direction, -1));
 	reflect_dir = reflect(light_dir, scene->record.normal);
 	spec = pow(fmax(0.0, vec3_dot(reflect_dir, view_dir)), ksn);


### PR DESCRIPTION
**오브젝트별 diffuse, specular 상수 추가**

이 시점부터 object는 ks, kd, ksn값을 무조건 추가해야 함.
```
sp 0,0,-1  1  25,51,127 1 1 128 bm texture.xpm bump.xpm

sp 0,0,-1  1  25,51,127 [kd] [ks] [ksn] bm texture.xpm bump.xpm
sp 0,0,-1  1  25,51,127 [0-1] [0-1] [0-INF] bm texture.xpm bump.xpm
```

- kd, ks, ksn 값을 받기 위해 구조체 및 enum 수정

- t_parse 변수값 추가
t_object에 전달목적
<img width="200" alt="image" src="https://user-images.githubusercontent.com/63245869/163082139-a97504e4-6f92-46c7-959d-ddf1eb70d187.png">

- t_info 변수값 추가
type 정의를 내려서 함수 가독성 용이하게
<img width="200" alt="image" src="https://user-images.githubusercontent.com/63245869/163082205-5e529ffe-72eb-44ed-a67a-9dbe18d5b9ad.png">

- t_object 변수값 추가
물체의 특성
<img width="200" alt="image" src="https://user-images.githubusercontent.com/63245869/163082215-3a1e6460-3583-4163-8fe9-446cdd7e39c6.png">

- t_hit_record 변수값 추가
물체의 kd, ks, ksn값을 가져오기 위해 pointer로 선언
<img width="200" alt="image" src="https://user-images.githubusercontent.com/63245869/163082231-6dae9a56-ed0b-40a5-8e46-15efb8e67d79.png">

- kd, ks, ksn parsing, free을 위한 함수 추가

- kd, ks, ksn 값을 적용하기 위해 t_hit_record에서 object pointer 정의

- closes #76