### PR TITLE
fix: :bug: Fix parse syntax order.

### DIFF
--- a/include_bonus/parse_bonus.h
+++ b/include_bonus/parse_bonus.h
@@ -14,8 +14,7 @@ t_obj_list		*parse_to_str(int fd);
 // parse_str_set_bonus
 
 int				parse_set(t_parse *lst, char **str);
-int				parse_obj_spec_set(t_parse *lst, char **str, int idx);
-void			parse_texture_set(t_parse *lst, char **str, int idx);
+void			parse_color_obj_set(t_parse *lst, char **str, int idx);
 
 // parse_to_element
 
@@ -39,7 +38,6 @@ int				split_len(char **str);
 t_bool			is_scene_env_valid(t_parse_list *lst);
 t_bool			is_info_valid(t_obj_type id, t_info info);
 t_bool			is_element_valid(t_obj_type id, char **str);
-t_bool			is_obj_spec_valid(t_obj_type id, char **str, int idx);
-t_bool			is_texture_valid(t_color_type id, char **str, int idx);
+t_bool			is_color_obj_valid(t_obj_type id, char **str, int idx);
 
 #endif

--- a/include_bonus/parse_bonus.h
+++ b/include_bonus/parse_bonus.h
@@ -38,6 +38,5 @@ int				split_len(char **str);
 t_bool			is_scene_env_valid(t_parse_list *lst);
 t_bool			is_info_valid(t_obj_type id, t_info info);
 t_bool			is_element_valid(t_obj_type id, char **str);
-t_bool			is_color_obj_valid(t_obj_type id, char **str, int idx);
 
 #endif

--- a/include_bonus/structure_bonus.h
+++ b/include_bonus/structure_bonus.h
@@ -56,6 +56,7 @@ typedef struct s_eq
 
 typedef enum e_color_type
 {
+	NOTCOLOR = -1,
 	COLOR = 0,
 	CHECKBOARD = 1,
 	BUMPMAP = 2,

--- a/src_bonus/parse/parse_bool_bonus.c
+++ b/src_bonus/parse/parse_bool_bonus.c
@@ -71,31 +71,3 @@ t_bool	is_element_valid(t_obj_type id, char **str)
 		return (FALSE);
 	return (TRUE);
 }
-
-t_bool	is_color_obj_valid(t_obj_type id, char **str, int idx)
-{
-	int		i;
-
-	i = 0;
-	while (str[i] != NULL)
-		++i;
-	if (id == AMBIENT || id == POINT_LIGHT)
-	{
-		if (i != ++idx)
-			return (FALSE);
-	}
-	else if (id == SPHERE || id == PLANE || id == CYLINDER || id == CONE)
-	{
-		if (i < idx)
-			return (FALSE);
-		if (ft_strcmp(str[idx], "rgb") == 0 && i - idx == 5)
-			return (TRUE);
-		else if (ft_strcmp(str[idx], "ck") == 0 && i - idx == 8)
-			return (TRUE);
-		else if (ft_strcmp(str[idx], "bm") == 0 && \
-		(i - idx == 5 || i - idx == 6))
-			return (TRUE);
-		return (FALSE);
-	}
-	return (TRUE);
-}

--- a/src_bonus/parse/parse_bool_bonus.c
+++ b/src_bonus/parse/parse_bool_bonus.c
@@ -44,9 +44,7 @@ t_bool	is_info_valid(t_obj_type id, t_info info)
 		return (TRUE);
 	else if (info == FOV && (id == CAMERA))
 		return (TRUE);
-	else if (info == RGB && \
-	(id == AMBIENT || id == POINT_LIGHT || id == SPHERE || id == PLANE || \
-	id == CYLINDER || id == CONE))
+	else if (info == RGB && (id == AMBIENT || id == POINT_LIGHT))
 		return (TRUE);
 	else if ((info == KD || info == KS || info == KSN) && \
 	(id == SPHERE || id == PLANE || id == CYLINDER || id == CONE))
@@ -67,7 +65,6 @@ t_bool	is_element_valid(t_obj_type id, char **str)
 	idx += is_info_valid(id, DIAMETER);
 	idx += is_info_valid(id, HEIGHT);
 	idx += is_info_valid(id, FOV);
-	idx += is_info_valid(id, RGB);
 	while (str[i] != NULL)
 		++i;
 	if (i < idx)
@@ -75,33 +72,30 @@ t_bool	is_element_valid(t_obj_type id, char **str)
 	return (TRUE);
 }
 
-t_bool	is_obj_spec_valid(t_obj_type id, char **str, int idx)
+t_bool	is_color_obj_valid(t_obj_type id, char **str, int idx)
 {
 	int		i;
 
 	i = 0;
-	idx += is_info_valid(id, KD);
-	idx += is_info_valid(id, KS);
-	idx += is_info_valid(id, KSN);
 	while (str[i] != NULL)
 		++i;
-	if (i < idx)
+	if (id == AMBIENT || id == POINT_LIGHT)
+	{
+		if (i != ++idx)
+			return (FALSE);
+	}
+	else if (id == SPHERE || id == PLANE || id == CYLINDER || id == CONE)
+	{
+		if (i < idx)
+			return (FALSE);
+		if (ft_strcmp(str[idx], "rgb") == 0 && i - idx == 5)
+			return (TRUE);
+		else if (ft_strcmp(str[idx], "ck") == 0 && i - idx == 8)
+			return (TRUE);
+		else if (ft_strcmp(str[idx], "bm") == 0 && \
+		(i - idx == 5 || i - idx == 6))
+			return (TRUE);
 		return (FALSE);
+	}
 	return (TRUE);
-}
-
-t_bool	is_texture_valid(t_color_type id, char **str, int idx)
-{
-	int		i;
-
-	i = 0;
-	while (str[i] != NULL)
-		++i;
-	if (i <= idx)
-		return (FALSE);
-	if (id == CHECKBOARD && i - idx == 4)
-		return (TRUE);
-	else if (id == BUMPMAP && (i - idx == 2 || i - idx == 3))
-		return (TRUE);
-	return (FALSE);
 }

--- a/src_bonus/parse/parse_str_set_bonus.c
+++ b/src_bonus/parse/parse_str_set_bonus.c
@@ -22,15 +22,32 @@ static t_obj_type	element_type_get(char *s)
 	return (NOTTYPE);
 }
 
-static t_color_type	color_type_get(char *s)
+static t_color_type	color_obj_valid_get(t_obj_type id, char **str, int idx)
 {
-	if (!ft_strcmp(s, "rgb"))
-		return (COLOR);
-	else if (!ft_strcmp(s, "ck"))
-		return (CHECKBOARD);
-	else if (!ft_strcmp(s, "bm"))
-		return (BUMPMAP);
-	return (NOTCOLOR);
+	int		i;
+
+	i = 0;
+	while (str[i] != NULL)
+		++i;
+	if (id == AMBIENT || id == POINT_LIGHT)
+	{
+		if (i != ++idx)
+			return (NOTCOLOR);
+	}
+	else if (id == SPHERE || id == PLANE || id == CYLINDER || id == CONE)
+	{
+		if (i < idx)
+			return (NOTCOLOR);
+		if (ft_strcmp(str[idx], "rgb") == 0 && i - idx == 5)
+			return (COLOR);
+		else if (ft_strcmp(str[idx], "ck") == 0 && i - idx == 8)
+			return (CHECKBOARD);
+		else if (ft_strcmp(str[idx], "bm") == 0 && \
+		(i - idx == 5 || i - idx == 6))
+			return (BUMPMAP);
+		return (NOTCOLOR);
+	}
+	return (COLOR);
 }
 
 int	parse_set(t_parse *lst, char **str)
@@ -61,10 +78,7 @@ int	parse_set(t_parse *lst, char **str)
 
 static void	parse_obj_set(t_parse *lst, char **str, int idx)
 {
-	lst->t_ident = str[idx++];
-	lst->texture_id = color_type_get(lst->t_ident);
-	if (lst->texture_id == NOTCOLOR)
-		error_user("invalid color name.\n");
+	idx++;
 	if (lst->texture_id == COLOR)
 		lst->rgb = str[idx++];
 	else if (lst->texture_id == CHECKBOARD)
@@ -85,7 +99,8 @@ static void	parse_obj_set(t_parse *lst, char **str, int idx)
 
 void	parse_color_obj_set(t_parse *lst, char **str, int idx)
 {
-	if (is_color_obj_valid(lst->id, str, idx) == FALSE)
+	lst->texture_id = color_obj_valid_get(lst->id, str, idx);
+	if (lst->texture_id == NOTCOLOR)
 		error_user("Color info or object spec - Not standard.");
 	if (lst->id == AMBIENT || lst->id == POINT_LIGHT)
 		lst->rgb = str[idx++];

--- a/src_bonus/parse/parse_str_set_bonus.c
+++ b/src_bonus/parse/parse_str_set_bonus.c
@@ -22,6 +22,17 @@ static t_obj_type	element_type_get(char *s)
 	return (NOTTYPE);
 }
 
+static t_color_type	color_type_get(char *s)
+{
+	if (!ft_strcmp(s, "rgb"))
+		return (COLOR);
+	else if (!ft_strcmp(s, "ck"))
+		return (CHECKBOARD);
+	else if (!ft_strcmp(s, "bm"))
+		return (BUMPMAP);
+	return (NOTCOLOR);
+}
+
 int	parse_set(t_parse *lst, char **str)
 {
 	int		idx;
@@ -45,48 +56,40 @@ int	parse_set(t_parse *lst, char **str)
 		lst->height = str[idx++];
 	if (is_info_valid(lst->id, FOV))
 		lst->fov = str[idx++];
-	if (is_info_valid(lst->id, RGB))
+	return (idx);
+}
+
+static void	parse_obj_set(t_parse *lst, char **str, int idx)
+{
+	lst->t_ident = str[idx++];
+	lst->texture_id = color_type_get(lst->t_ident);
+	if (lst->texture_id == NOTCOLOR)
+		error_user("invalid color name.\n");
+	if (lst->texture_id == COLOR)
 		lst->rgb = str[idx++];
-	return (idx);
-}
-
-int	parse_obj_spec_set(t_parse *lst, char **str, int idx)
-{
-	if (is_obj_spec_valid(lst->id, str, idx) == FALSE)
-		error_user("objecet spec came in wrong.\n");
-	if (is_info_valid(lst->id, KD))
-		lst->kd = str[idx++];
-	if (is_info_valid(lst->id, KS))
-		lst->ks = str[idx++];
-	if (is_info_valid(lst->id, KSN))
-		lst->ksn = str[idx++];
-	return (idx);
-}
-
-void	parse_texture_set(t_parse *lst, char **str, int idx)
-{
-	if (idx == split_len(str))
+	else if (lst->texture_id == CHECKBOARD)
 	{
-		lst->texture_id = COLOR;
-		return ;
-	}
-	lst->t_ident = str[idx];
-	if (ft_strcmp(lst->t_ident, "ck") == 0)
-		lst->texture_id = CHECKBOARD;
-	else if (ft_strcmp(lst->t_ident, "bm") == 0)
-		lst->texture_id = BUMPMAP;
-	else
-		error_user("invalid texture name.\n");
-	if (is_texture_valid(lst->texture_id, str, idx) == FALSE)
-		error_user("texture info came in wrong.\n");
-	if (lst->texture_id == CHECKBOARD)
-	{
-		lst->check_color = str[++idx];
-		lst->check_width = str[++idx];
-		lst->check_height = str[++idx];
+		lst->rgb = str[idx++];
+		lst->check_color = str[idx++];
+		lst->check_width = str[idx++];
+		lst->check_height = str[idx++];
 	}
 	if (lst->texture_id == BUMPMAP)
-		lst->texture_file = str[++idx];
-	if (lst->texture_id == BUMPMAP && str[++idx] != NULL)
-		lst->bump_file = str[idx];
+		lst->texture_file = str[idx++];
+	if (lst->texture_id == BUMPMAP && str[idx + 3] != NULL)
+		lst->bump_file = str[idx++];
+	lst->kd = str[idx++];
+	lst->ks = str[idx++];
+	lst->ksn = str[idx++];
+}
+
+void	parse_color_obj_set(t_parse *lst, char **str, int idx)
+{
+	if (is_color_obj_valid(lst->id, str, idx) == FALSE)
+		error_user("Color info or object spec - Not standard.");
+	if (lst->id == AMBIENT || lst->id == POINT_LIGHT)
+		lst->rgb = str[idx++];
+	else if (lst->id == SPHERE || lst->id == PLANE || \
+	lst->id == CYLINDER || lst->id == CONE)
+		parse_obj_set(lst, str, idx);
 }

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -21,8 +21,7 @@ static t_parse	*element_set(char *line)
 		return (del_split(str_splited));
 	}
 	idx = parse_set(lst, str_splited);
-	idx = parse_obj_spec_set(lst, str_splited, idx);
-	parse_texture_set(lst, str_splited, idx);
+	parse_color_obj_set(lst, str_splited, idx);
 	free(str_splited);
 	return (lst);
 }

--- a/src_bonus/scene/objects_bonus.c
+++ b/src_bonus/scene/objects_bonus.c
@@ -33,9 +33,10 @@ static t_xpm_image	*image_get(char *filename, void *mlx_ptr)
 static void	texture_get(t_obj_list *l, t_parse *p, void *mlx_ptr)
 {
 	if (p->texture_id == COLOR)
-		return ;
+		l->color.color = vec_get(p->rgb, 0, 255);
 	else if (p->texture_id == CHECKBOARD)
 	{
+		l->color.color = vec_get(p->rgb, 0, 255);
 		l->color.checkboard = ft_calloc(sizeof(t_checkboard), 0);
 		l->color.checkboard->check_color = vec_get(p->check_color, 0, 255);
 		l->color.checkboard->width = double_get(p->check_width, 0, INFINITY);
@@ -74,7 +75,6 @@ void	object_set(t_scene *scene, t_parse_list *lst, void *mlx_ptr)
 	object->ks = double_get(lst_parse->ks, 0, 1);
 	object->ksn = double_get(lst_parse->ksn, 0, INFINITY);
 	lst_new->type = lst_parse->id;
-	lst_new->color.color = vec_get(lst_parse->rgb, 0, 255);
 	texture_get(lst_new, lst_parse, mlx_ptr);
 	lst_new->object = object;
 }


### PR DESCRIPTION
**rt파일에 대한 파싱 순서 수정.**

**Mandatory** 기준 파싱
```
[x,y,z point] [braghness ratio] [normalized vector] [diameter] [height] [FOV] [RGB]

A	[bright ratio]	[RGB]
C	[x,y,z point]	[normalized vector]	[FOV]
L	[x,y,z point]	[braghness ratio]	[RGB]
sp	[x,y,z point]	[diameter]		[RGB]
pl	[x,y,z point]	[normalized vector]	[RGB]
cy	[x,y,z point]	[normalized vector]	[diameter]	[height]	[RGB]
co	[x,y,z point]	[normalized vector]	[diameter]	[height]	[RGB]
```

**Bonus** 기준 파싱
```
[x,y,z point] [braghness ratio] [normalized vector] [diameter] [height] [FOV] [texture info] [object spec]

A	[bright ratio]	[RGB]
C	[x,y,z point]	[normalized vector]	[FOV]
L	[x,y,z point]	[braghness ratio]	[RGB]
sp	[x,y,z point]	[diameter]		[texture info]	[object spec]
pl	[x,y,z point]	[normalized vector]	[texture info]	[object spec]
cy	[x,y,z point]	[normalized vector]	[diameter]	[height]	[texture info]	[object spec]
co	[x,y,z point]	[normalized vector]	[diameter]	[height]	[texture info]	[object spec]
```

추가된 부분의 문법
```
[texture info]
rgb [color1]
ck [color1] [color2] [width] [height]
bm [texture file] [bumpmap file]

[object spec]
[kd] [ks] [ksn]
```

이전 Bonus_object parse
```
sp	... [RGB]	[object spec]	[texture info]
pl	... [RGB]	[object spec]	[texture info]
cy	... [RGB] 	[object spec]	[texture info]
co	... [RGB] 	[object spec]	[texture info]
```

detail syntax에 대해서는 나중에 따로 작성하겠습니다.

- closes #85