### PR TITLE
Cjang/issue77/parse exception check

### DIFF
--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -20,7 +20,7 @@ asciiV		:= ft_atof ft_isdigit ft_isspace
 mathV		:= ft_clamp ft_fmod_abs
 memoryV		:= ft_bzero ft_calloc ft_memset
 readV		:= get_next_line
-stringV		:= ft_split ft_strcmp ft_strdup ft_strjoin ft_strlcpy ft_strlen ft_strncmp
+stringV		:= ft_split ft_strcmp ft_strdup ft_strjoin ft_strlcpy ft_strlen ft_strncmp ft_strsep
 writeV		:= ft_putstr_fd ft_write ft_writes
 
 

--- a/lib/libft/include/ft_string.h
+++ b/lib/libft/include/ft_string.h
@@ -8,5 +8,6 @@ char	*ft_strjoin(char const *s1, char const *s2);
 size_t	ft_strlcpy(char *dst, const char *src, size_t dstsize);
 size_t	ft_strlen(const char *str);
 int		ft_strncmp(const char *s1, const char *s2, size_t n);
+char	*ft_strsep(char **stringp, const char delim);
 
 #endif

--- a/lib/libft/src/string/ft_strsep.c
+++ b/lib/libft/src/string/ft_strsep.c
@@ -1,0 +1,22 @@
+#include "libft.h"
+
+char	*ft_strsep(char **stringp, const char delim)
+{
+	char	*tmp;
+
+	tmp = *stringp;
+	if (tmp == NULL)
+		return (NULL);
+	while (**stringp)
+	{
+		if (**stringp == delim)
+		{
+			**stringp = '\0';
+			(*stringp)++;
+			return (tmp);
+		}
+		(*stringp)++;
+	}
+	*stringp = NULL;
+	return (tmp);
+}

--- a/src/parse/parse_to_str.c
+++ b/src/parse/parse_to_str.c
@@ -30,7 +30,7 @@ static void	parse_set(t_parse *lst, char **str)
 	lst->ident = str[0];
 	lst->id = element_type_get(str[0]);
 	if (lst->id == NOTTYPE)
-		error_user("invalid element name.\n");
+		error_user("Invalid element name.\n");
 	if (is_element_valid(lst->id, str) == FALSE)
 		error_user("Elements came in more than standard.\n");
 	if (is_info_valid(lst->id, POINT))
@@ -92,6 +92,6 @@ t_obj_list	*parse_to_str(int fd)
 			free(line);
 	}
 	if (is_scene_env_valid(lst_head) == FALSE)
-		error_user("Each Ambient, Light and Camera must be one.");
+		error_user("Each Ambient, Light and Camera must be one.\n");
 	return (lst_head);
 }

--- a/src_bonus/parse/parse_str_set_bonus.c
+++ b/src_bonus/parse/parse_str_set_bonus.c
@@ -101,7 +101,7 @@ void	parse_color_obj_set(t_parse *lst, char **str, int idx)
 {
 	lst->texture_id = color_obj_valid_get(lst->id, str, idx);
 	if (lst->texture_id == NOTCOLOR)
-		error_user("Color info or object spec - Not standard.");
+		error_user("Color info or object spec - Not standard.\n");
 	if (lst->id == AMBIENT || lst->id == POINT_LIGHT)
 		lst->rgb = str[idx++];
 	else if (lst->id == SPHERE || lst->id == PLANE || \

--- a/src_bonus/parse/parse_str_set_bonus.c
+++ b/src_bonus/parse/parse_str_set_bonus.c
@@ -78,7 +78,7 @@ int	parse_set(t_parse *lst, char **str)
 
 static void	parse_obj_set(t_parse *lst, char **str, int idx)
 {
-	idx++;
+	lst->t_ident = str[idx++];
 	if (lst->texture_id == COLOR)
 		lst->rgb = str[idx++];
 	else if (lst->texture_id == CHECKBOARD)

--- a/src_bonus/parse/parse_to_num_bonus.c
+++ b/src_bonus/parse/parse_to_num_bonus.c
@@ -3,6 +3,7 @@
 #include "vector3_bonus.h"
 #include "error_bonus.h"
 #include <math.h>
+#include <stdlib.h>
 
 double	double_get(char *s, double min, double max)
 {
@@ -24,20 +25,18 @@ double	double_get(char *s, double min, double max)
 struct s_vec3	vec_get(char *s, double min, double max)
 {
 	struct s_vec3	vec;
-	char			**str_splited;
+	char			*s_tmp;
+	char			*s_tmp_ptr;
 	int				i;
 
 	i = 0;
-	str_splited = ft_split(s, ",");
-	if (str_splited == NULL)
-		error_user("color_get - dynamic allocation problem.\n");
-	while (str_splited[i] != NULL)
-		i++;
-	if (i != 3)
+	s_tmp = ft_strdup(s);
+	s_tmp_ptr = s_tmp;
+	vec.x = double_get(ft_strsep(&s_tmp, ','), min, max);
+	vec.y = double_get(ft_strsep(&s_tmp, ','), min, max);
+	vec.z = double_get(ft_strsep(&s_tmp, ','), min, max);
+	if (ft_strsep(&s_tmp, ',') != NULL)
 		error_user("Elements must came in standard.\n");
-	vec.x = double_get(str_splited[0], min, max);
-	vec.y = double_get(str_splited[1], min, max);
-	vec.z = double_get(str_splited[2], min, max);
 	if (min == -1 && max == 1)
 	{
 		if (vec3_length(vec) == 0.0)
@@ -46,6 +45,6 @@ struct s_vec3	vec_get(char *s, double min, double max)
 	}
 	else if (min == 0 && max == 255)
 		vec = vec3_divide_scalar(vec, 255);
-	del_split(str_splited);
+	free(s_tmp_ptr);
 	return (vec);
 }

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -51,6 +51,6 @@ t_obj_list	*parse_to_str(int fd)
 	}
 	if (is_scene_env_valid(lst_head) == FALSE)
 		error_user("Each Ambient and Camera must be one, \
-Light must be more than one.");
+Light must be more than one.\n");
 	return (lst_head);
 }


### PR DESCRIPTION
- 쉼표일 때 예외처리
쉼표일 때 유효성 검사는 ft_split이 아니라, ft_strsep를 이용하여 구분자를 기준으로 내용을 분리하는 방식이어야 했습니다.
아래와 같은 값을 예외처리 하기 위해 ft_strsep를 이용하였습니다.
```
3,22,,111
기존 : [3] [22] [111]
현재 : [3] [22] [] [111]

3,22,111,
기존 : [3] [222] [111]
현재 : [3] [22] [111] []

,3,22,111
기존 : [3] [222] [111]
현재 : [] [3] [22] [111]
```


- error_user 매개변수 문자 보완
개행문자가 없거나, 첫번째 문자가 소문자인 경우 수정하였습니다.

- leaks 해결
특정 문자열을 t_parse->t_ident에 정의내리지 않아서 메모리를 잃어버린 부분 해결하였습니다.


- closes #77 
- closes #88
- closes #89
