### PR TITLE
Cjang/issue80/parse error fix bonus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ sceneB		:= ambient camera light objects scene
 traceB		:= hit_cone hit_cylinder hit_plane hit_sphere hit image_mapping \
 				phong_illumination phong_light ray texture util
 parseB		:= parse_bool parse_read parse_to_num parse_to_element \
-				parse_to_str parse_utils parse_str_set
+				parse_to_str parse_utils parse_str_set parse_str_get
 vector3B	:= vector_operation1 vector_operation2 vector_operation3 \
 				vector_set vector_matrix
 

--- a/include_bonus/parse_bonus.h
+++ b/include_bonus/parse_bonus.h
@@ -11,10 +11,15 @@ int				fd_get(int argv, char **argc);
 
 t_obj_list		*parse_to_str(int fd);
 
-// parse_str_set_bonus
+// parse_str_set
 
 int				parse_set(t_parse *lst, char **str);
 void			parse_color_obj_set(t_parse *lst, char **str, int idx);
+
+// parse_str_get
+
+t_obj_type		element_type_get(char *s);
+t_color_type	color_obj_valid_get(t_obj_type id, char **str, int idx);
 
 // parse_to_element
 

--- a/include_bonus/structure_bonus.h
+++ b/include_bonus/structure_bonus.h
@@ -56,6 +56,8 @@ typedef struct s_eq
 
 typedef enum e_color_type
 {
+	ERROR_LESS = -3,
+	ERROR_MORE = -2,
 	NOTCOLOR = -1,
 	COLOR = 0,
 	CHECKBOARD = 1,

--- a/lib/libft/src/ascii/ft_atof.c
+++ b/lib/libft/src/ascii/ft_atof.c
@@ -54,10 +54,6 @@ static double	str_to_decimal(char **str)
 	return (decimal);
 }
 
-/*
-e+10 e-10 E+10 E-10 미구현, 찾아봐야할듯
-25줄 이슈 있음
-*/
 double	ft_atof(char *str, t_res *valid)
 {
 	int			sign;

--- a/src_bonus/main_bonus.c
+++ b/src_bonus/main_bonus.c
@@ -10,7 +10,6 @@ static void	program_init(t_mlx *mlx)
 	mlx->img.img = mlx_new_image(mlx->mlx, WIN_WIDTH, WIN_HEIGHT);
 	mlx->img.addr = mlx_get_data_addr(
 			mlx->img.img, &mlx->img.bpp, &mlx->img.line, &mlx->img.endian);
-	mlx->win = mlx_new_window(mlx->mlx, WIN_WIDTH, WIN_HEIGHT, "miniRT");
 }
 
 int	main(int argv, char **argc)
@@ -25,6 +24,7 @@ int	main(int argv, char **argc)
 	program_init(&mlx);
 	scene = parse_to_element(info, mlx.mlx);
 	del_obj_lst_parse(&info);
+	mlx.win = mlx_new_window(mlx.mlx, WIN_WIDTH, WIN_HEIGHT, "miniRT");
 	scene_draw(&mlx, scene);
 	mlx_hook(mlx.win, X11_KEYPRESS, 1L << 0, key_press, &mlx);
 	mlx_hook(mlx.win, X11_CLOSEBTN, 1L << 2, exit_button, &mlx);

--- a/src_bonus/parse/parse_str_get_bonus.c
+++ b/src_bonus/parse/parse_str_get_bonus.c
@@ -1,0 +1,72 @@
+#include "libft.h"
+#include "parse_bonus.h"
+#include <stdlib.h>
+
+t_obj_type	element_type_get(char *s)
+{
+	if (!ft_strcmp(s, "A"))
+		return (AMBIENT);
+	else if (!ft_strcmp(s, "C"))
+		return (CAMERA);
+	else if (!ft_strcmp(s, "L"))
+		return (POINT_LIGHT);
+	else if (!ft_strcmp(s, "sp"))
+		return (SPHERE);
+	else if (!ft_strcmp(s, "pl"))
+		return (PLANE);
+	else if (!ft_strcmp(s, "cy"))
+		return (CYLINDER);
+	else if (!ft_strcmp(s, "co"))
+		return (CONE);
+	return (NOTTYPE);
+}
+
+static t_color_type	obj_info_get(char **str, int len, int idx)
+{
+	if (len < idx)
+		return (ERROR_LESS);
+	if (ft_strcmp(str[idx], "rgb") == 0)
+	{
+		if (len - idx == 5)
+			return (COLOR);
+		idx += 5;
+	}
+	else if (ft_strcmp(str[idx], "ck") == 0)
+	{
+		if (len - idx == 8)
+			return (CHECKBOARD);
+		idx += 8;
+	}
+	else if (ft_strcmp(str[idx], "bm") == 0)
+	{
+		if (len - idx == 5 || len - idx == 6)
+			return (BUMPMAP);
+		idx += 5;
+	}
+	else
+		return (NOTCOLOR);
+	if (len < idx)
+		return (ERROR_LESS);
+	return (ERROR_MORE);
+}
+
+t_color_type	color_obj_valid_get(t_obj_type id, char **str, int idx)
+{
+	int		i;
+
+	i = 0;
+	while (str[i] != NULL)
+		++i;
+	if (id == AMBIENT || id == POINT_LIGHT)
+	{
+		++idx;
+		if (i < idx)
+			return (ERROR_LESS);
+		else if (i > idx)
+			return (ERROR_MORE);
+		return (COLOR);
+	}
+	else if (id == SPHERE || id == PLANE || id == CYLINDER || id == CONE)
+		return (obj_info_get(str, i, idx));
+	return (COLOR);
+}

--- a/src_bonus/parse/parse_str_set_bonus.c
+++ b/src_bonus/parse/parse_str_set_bonus.c
@@ -3,53 +3,6 @@
 #include "error_bonus.h"
 #include <stdlib.h>
 
-static t_obj_type	element_type_get(char *s)
-{
-	if (!ft_strcmp(s, "A"))
-		return (AMBIENT);
-	else if (!ft_strcmp(s, "C"))
-		return (CAMERA);
-	else if (!ft_strcmp(s, "L"))
-		return (POINT_LIGHT);
-	else if (!ft_strcmp(s, "sp"))
-		return (SPHERE);
-	else if (!ft_strcmp(s, "pl"))
-		return (PLANE);
-	else if (!ft_strcmp(s, "cy"))
-		return (CYLINDER);
-	else if (!ft_strcmp(s, "co"))
-		return (CONE);
-	return (NOTTYPE);
-}
-
-static t_color_type	color_obj_valid_get(t_obj_type id, char **str, int idx)
-{
-	int		i;
-
-	i = 0;
-	while (str[i] != NULL)
-		++i;
-	if (id == AMBIENT || id == POINT_LIGHT)
-	{
-		if (i != ++idx)
-			return (NOTCOLOR);
-	}
-	else if (id == SPHERE || id == PLANE || id == CYLINDER || id == CONE)
-	{
-		if (i < idx)
-			return (NOTCOLOR);
-		if (ft_strcmp(str[idx], "rgb") == 0 && i - idx == 5)
-			return (COLOR);
-		else if (ft_strcmp(str[idx], "ck") == 0 && i - idx == 8)
-			return (CHECKBOARD);
-		else if (ft_strcmp(str[idx], "bm") == 0 && \
-		(i - idx == 5 || i - idx == 6))
-			return (BUMPMAP);
-		return (NOTCOLOR);
-	}
-	return (COLOR);
-}
-
 int	parse_set(t_parse *lst, char **str)
 {
 	int		idx;
@@ -58,9 +11,9 @@ int	parse_set(t_parse *lst, char **str)
 	lst->ident = str[0];
 	lst->id = element_type_get(str[0]);
 	if (lst->id == NOTTYPE)
-		error_user("invalid element name.\n");
+		error_user("Invalid element name.\n");
 	if (is_element_valid(lst->id, str) == FALSE)
-		error_user("Elements came in more than standard.\n");
+		error_user("Elements came in less than standard.\n");
 	if (is_info_valid(lst->id, POINT))
 		lst->point = str[idx++];
 	if (is_info_valid(lst->id, BRI_RATIO))
@@ -100,8 +53,12 @@ static void	parse_obj_set(t_parse *lst, char **str, int idx)
 void	parse_color_obj_set(t_parse *lst, char **str, int idx)
 {
 	lst->texture_id = color_obj_valid_get(lst->id, str, idx);
-	if (lst->texture_id == NOTCOLOR)
-		error_user("Color info or object spec - Not standard.\n");
+	if (lst->texture_id == ERROR_LESS)
+		error_user("Elements came in less than standard.\n");
+	else if (lst->texture_id == ERROR_MORE)
+		error_user("Elements came in more than standard.\n");
+	else if (lst->texture_id == NOTCOLOR)
+		error_user("Color type for that location is not standard.\n");
 	if (lst->id == AMBIENT || lst->id == POINT_LIGHT)
 		lst->rgb = str[idx++];
 	else if (lst->id == SPHERE || lst->id == PLANE || \

--- a/src_bonus/parse/parse_to_num_bonus.c
+++ b/src_bonus/parse/parse_to_num_bonus.c
@@ -17,6 +17,10 @@ double	double_get(char *s, double min, double max)
 		return (d);
 	else if (min == 0 && max == INFINITY && d < 0)
 		error_user("The properties of the shape must be positive.\n");
+	else if (min == 0 && max == 180 && d >= 180)
+		error_user("FOV range should be under 180.\n");
+	else if (min == 0 && max == 180 && d < 0)
+		error_user("FOV range should be over 0.\n");
 	if (d < min || d > max)
 		error_user("Elements must came in standard.\n");
 	return (d);

--- a/src_bonus/parse/parse_to_num_bonus.c
+++ b/src_bonus/parse/parse_to_num_bonus.c
@@ -38,7 +38,7 @@ struct s_vec3	vec_get(char *s, double min, double max)
 	vec.y = double_get(ft_strsep(&s_tmp, ','), min, max);
 	vec.z = double_get(ft_strsep(&s_tmp, ','), min, max);
 	if (ft_strsep(&s_tmp, ',') != NULL)
-		error_user("[x,y,z] elements must came in standard.\n");
+		error_user("[x,y,z] or [r,g,b] elements must came in standard.\n");
 	if (min == -1 && max == 1)
 	{
 		if (vec3_length(vec) == 0.0)

--- a/src_bonus/parse/parse_to_num_bonus.c
+++ b/src_bonus/parse/parse_to_num_bonus.c
@@ -12,7 +12,7 @@ double	double_get(char *s, double min, double max)
 
 	d = ft_atof(s, &res);
 	if (res != CLEAN)
-		error_user("Elements must came in standard.\n");
+		error_user("Number must came in correct type.\n");
 	if (min == 0 && max == 0)
 		return (d);
 	else if (min == 0 && max == INFINITY && d < 0)
@@ -22,7 +22,7 @@ double	double_get(char *s, double min, double max)
 	else if (min == 0 && max == 180 && d < 0)
 		error_user("FOV range should be over 0.\n");
 	if (d < min || d > max)
-		error_user("Elements must came in standard.\n");
+		error_user("Number must came in standard range.\n");
 	return (d);
 }
 
@@ -31,20 +31,18 @@ struct s_vec3	vec_get(char *s, double min, double max)
 	struct s_vec3	vec;
 	char			*s_tmp;
 	char			*s_tmp_ptr;
-	int				i;
 
-	i = 0;
 	s_tmp = ft_strdup(s);
 	s_tmp_ptr = s_tmp;
 	vec.x = double_get(ft_strsep(&s_tmp, ','), min, max);
 	vec.y = double_get(ft_strsep(&s_tmp, ','), min, max);
 	vec.z = double_get(ft_strsep(&s_tmp, ','), min, max);
 	if (ft_strsep(&s_tmp, ',') != NULL)
-		error_user("Elements must came in standard.\n");
+		error_user("[x,y,z] elements must came in standard.\n");
 	if (min == -1 && max == 1)
 	{
 		if (vec3_length(vec) == 0.0)
-			error_user("Elements must came in standard.\n");
+			error_user("Normalized vector must came in standard.\n");
 		vec = vec3_unit(vec);
 	}
 	else if (min == 0 && max == 255)

--- a/src_bonus/parse/parse_to_str_bonus.c
+++ b/src_bonus/parse/parse_to_str_bonus.c
@@ -41,7 +41,7 @@ t_obj_list	*parse_to_str(int fd)
 		if (gnl_ret == ERROR)
 			error_user("get_next_line error.\n");
 		else if (gnl_ret == READFAIL)
-			error_user("File format dose not match.\n");
+			error_user("File format does not match.\n");
 		lst_parse = element_set(line);
 		if (lst_parse != NULL)
 			obj_list_add_back(&lst_head, \


### PR DESCRIPTION
- **FOV range 수정**
참고 #94
- **string 파싱 중 나오는 에러 메세지 수정**
A에서 bright ratio 누락시 color info error 메세지 출력 ==> elements값 개수가 적다는 에러 메세지로 수정.
parse_to_str 파트에서는 elements의 정보를 알 수 없고, 개수만 파악하여 다음 파싱과정으로 보내기 때문에, 개수 출력이 적거나 많다는 정보의 메세지를 출력하는 것으로 수정하였습니다.
<img width="601" alt="image" src="https://user-images.githubusercontent.com/63245869/163666511-383b6656-9f3a-4f04-b3f0-a3f00bc62b2e.png">

<img width="594" alt="image" src="https://user-images.githubusercontent.com/63245869/163666519-4053ce4a-3f69-4fe4-98ef-9ef669f7a18b.png">

위 수정으로 인해 parse_str_get_bonus.c 파일 추가하였습니다.
- **mlx_new_window는 파싱이 성공할 때 실행될 수 있도록 수정**

- **파싱 중 number로 변환하는 부분에서의 에러 출력 보완**
parse_to_num_bonus.c 참고
- closes #91 
- closes #96 
- closes #97 
- closes #98 