### PR TITLE
Cjang/issue80/parse error fix

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -17,8 +17,10 @@ t_scene			*parse_to_element(t_parse_list *lst);
 
 // parse_to_num
 
+int				int_get(char *s, int min, int max);
 double			double_get(char *s, double min, double max);
-struct s_vec3	vec_get(char *s, double min, double max);
+struct s_vec3	vec_int_get(char *s, int min, int max);
+struct s_vec3	vec_double_get(char *s, double min, double max);
 
 // parse_utils
 

--- a/include_bonus/parse_bonus.h
+++ b/include_bonus/parse_bonus.h
@@ -27,8 +27,10 @@ t_scene			*parse_to_element(t_parse_list *lst, void *mlx_ptr);
 
 // parse_to_num
 
+int				int_get(char *s, int min, int max);
 double			double_get(char *s, double min, double max);
-struct s_vec3	vec_get(char *s, double min, double max);
+struct s_vec3	vec_int_get(char *s, int min, int max);
+struct s_vec3	vec_double_get(char *s, double min, double max);
 
 // parse_utils
 

--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -16,7 +16,7 @@ INCD		:= -I./include/
 # ===== Packages =====
 PKGS		:= math memory string write ascii read
 
-asciiV		:= ft_atof ft_isdigit ft_isspace
+asciiV		:= ft_atof ft_atoi ft_isdigit ft_isspace
 mathV		:= ft_clamp ft_fmod_abs
 memoryV		:= ft_bzero ft_calloc ft_memset
 readV		:= get_next_line

--- a/lib/libft/include/ft_ascii.h
+++ b/lib/libft/include/ft_ascii.h
@@ -4,6 +4,7 @@
 # include "libft_type.h"
 
 double	ft_atof(char *str, int *valid);
+int		ft_atoi(const char *str, t_res *valid);
 t_bool	ft_isdigit(int c);
 t_bool	ft_isspace(int c);
 

--- a/lib/libft/src/ascii/ft_atof.c
+++ b/lib/libft/src/ascii/ft_atof.c
@@ -1,5 +1,6 @@
 #include "libft.h"
 #include <stdlib.h>
+#include <math.h>
 
 static double	return_func(double d, t_res *valid, t_res res)
 {
@@ -39,16 +40,22 @@ static double	str_to_integer(char **str)
 static double	str_to_decimal(char **str)
 {
 	double	decimal;
+	double	deciaml_tmp;
 	int		idx;
 
 	decimal = 0.0;
 	idx = 0;
 	while (**str != '\0' && ft_isdigit(**str) == TRUE)
 	{
-		decimal = decimal * 10 + **str - '0';
+		deciaml_tmp = decimal * 10 + **str - '0';
+		if (deciaml_tmp == INFINITY)
+			break ;
+		decimal = deciaml_tmp;
 		*str += 1;
 		++idx;
 	}
+	while (**str != '\0' && ft_isdigit(**str) == TRUE)
+		*str += 1;
 	while (--idx >= 0)
 		decimal /= 10;
 	return (decimal);

--- a/lib/libft/src/ascii/ft_atoi.c
+++ b/lib/libft/src/ascii/ft_atoi.c
@@ -1,0 +1,50 @@
+#include "libft.h"
+
+static double	return_func(int i, t_res *valid, t_res res)
+{
+	*valid = res;
+	return (i);
+}
+
+static unsigned long long	str_to_number(const char **str, int sign)
+{
+	unsigned long long	number;
+
+	number = 0;
+	while (**str >= '0' && **str <= '9')
+	{
+		if (sign == -1 && (number > 922337203685477580 || \
+		(number >= 922337203685477580 && **str - '0' >= 8)))
+			return (0);
+		else if (sign == 1 && (number > 922337203685477580 || \
+		(number >= 922337203685477580 && **str - '0' >= 7)))
+			return (-1);
+		number = number * 10 + **str - '0';
+		*str += 1;
+	}
+	return (number);
+}
+
+int	ft_atoi(const char *str, t_res *valid)
+{
+	int					sign;
+	unsigned long long	number;
+
+	sign = 1;
+	if (str == NULL)
+		return (return_func(0, valid, ERR));
+	while ((*str >= 9 && *str <= 13) || *str == 32)
+		str++;
+	if (*str == '+' || *str == '-')
+	{
+		if (*str == '-')
+			sign *= -1;
+		str++;
+	}
+	number = str_to_number(&str, sign);
+	if (*str == '\0')
+		*valid = CLEAN;
+	else
+		*valid = NOTCLEAN;
+	return (number * sign);
+}

--- a/src/parse/parse_to_num.c
+++ b/src/parse/parse_to_num.c
@@ -5,6 +5,19 @@
 #include <math.h>
 #include <stdlib.h>
 
+int	int_get(char *s, int min, int max)
+{
+	int		i;
+	t_res	res;
+
+	i = ft_atoi(s, &res);
+	if (res != CLEAN)
+		error_user("Number must came in correct type.\n");
+	if (i < min || i > max)
+		error_user("Number must came in standard range.\n");
+	return (i);
+}
+
 double	double_get(char *s, double min, double max)
 {
 	double	d;
@@ -26,7 +39,26 @@ double	double_get(char *s, double min, double max)
 	return (d);
 }
 
-struct s_vec3	vec_get(char *s, double min, double max)
+struct s_vec3	vec_int_get(char *s, int min, int max)
+{
+	struct s_vec3	vec;
+	char			*s_tmp;
+	char			*s_tmp_ptr;
+
+	s_tmp = ft_strdup(s);
+	s_tmp_ptr = s_tmp;
+	vec.x = int_get(ft_strsep(&s_tmp, ','), min, max);
+	vec.y = int_get(ft_strsep(&s_tmp, ','), min, max);
+	vec.z = int_get(ft_strsep(&s_tmp, ','), min, max);
+	if (ft_strsep(&s_tmp, ',') != NULL)
+		error_user("[r,g,b] elements must came in standard.\n");
+	if (min == 0 && max == 255)
+		vec = vec3_divide_scalar(vec, 255);
+	free(s_tmp_ptr);
+	return (vec);
+}
+
+struct s_vec3	vec_double_get(char *s, double min, double max)
 {
 	struct s_vec3	vec;
 	char			*s_tmp;

--- a/src/scene/ambient.c
+++ b/src/scene/ambient.c
@@ -8,6 +8,6 @@ t_ambient	ambient_set(t_parse_list *lst)
 
 	lst_parse = lst->object;
 	ambient.light_ratio = double_get(lst_parse->bri_ratio, 0.0, 1.0);
-	ambient.light_color = vec_get(lst_parse->rgb, 0, 255);
+	ambient.light_color = vec_int_get(lst_parse->rgb, 0, 255);
 	return (ambient);
 }

--- a/src/scene/camera.c
+++ b/src/scene/camera.c
@@ -12,8 +12,8 @@ t_camera	camera_prev_set(t_scene *scene, t_parse_list *lst)
 	double		h_fov;
 
 	lst_parse = lst->object;
-	origin = vec_get(lst_parse->point, 0, 0);
-	direct = vec_get(lst_parse->nor_vec, -1, 1);
+	origin = vec_double_get(lst_parse->point, 0, 0);
+	direct = vec_double_get(lst_parse->nor_vec, -1, 1);
 	h_fov = double_get(lst_parse->fov, 0, 180);
 	camera = camera_set(&scene->canvas, origin, direct, h_fov);
 	return (camera);

--- a/src/scene/light.c
+++ b/src/scene/light.c
@@ -13,9 +13,9 @@ void	light_set(t_scene *scene, t_parse_list *lst)
 	lst_new = ft_calloc(sizeof(t_obj_list), 0);
 	light = ft_calloc(sizeof(t_light), 0);
 	obj_list_add_back(&scene->lights, lst_new);
-	light->origin = vec_get(lst_parse->point, 0, 0);
+	light->origin = vec_double_get(lst_parse->point, 0, 0);
 	light->bright_ratio = double_get(lst_parse->bri_ratio, 0.0, 1.0);
 	lst_new->type = POINT_LIGHT;
-	lst_new->color = vec_get(lst_parse->rgb, 0, 255);
+	lst_new->color = vec_int_get(lst_parse->rgb, 0, 255);
 	lst_new->object = light;
 }

--- a/src/scene/objects.c
+++ b/src/scene/objects.c
@@ -14,11 +14,11 @@ void	sphere_set(t_scene *scene, t_parse_list *lst)
 	lst_new = ft_calloc(sizeof(t_obj_list), 0);
 	sphere = ft_calloc(sizeof(t_sphere), 0);
 	obj_list_add_back(&scene->objects, lst_new);
-	sphere->center = vec_get(lst_parse->point, 0, 0);
+	sphere->center = vec_double_get(lst_parse->point, 0, 0);
 	sphere->radius = double_get(lst_parse->diameter, 0, INFINITY) / 2;
 	sphere->radius2 = sphere->radius * sphere->radius;
 	lst_new->type = SPHERE;
-	lst_new->color = vec_get(lst_parse->rgb, 0, 255);
+	lst_new->color = vec_int_get(lst_parse->rgb, 0, 255);
 	lst_new->object = sphere;
 }
 
@@ -32,10 +32,10 @@ void	plane_set(t_scene *scene, t_parse_list *lst)
 	lst_new = ft_calloc(sizeof(t_obj_list), 0);
 	plane = ft_calloc(sizeof(t_plane), 0);
 	obj_list_add_back(&scene->objects, lst_new);
-	plane->point = vec_get(lst_parse->point, 0, 0);
-	plane->normal = vec_get(lst_parse->nor_vec, -1, 1);
+	plane->point = vec_double_get(lst_parse->point, 0, 0);
+	plane->normal = vec_double_get(lst_parse->nor_vec, -1, 1);
 	lst_new->type = PLANE;
-	lst_new->color = vec_get(lst_parse->rgb, 0, 255);
+	lst_new->color = vec_int_get(lst_parse->rgb, 0, 255);
 	lst_new->object = plane;
 }
 
@@ -49,12 +49,12 @@ void	cylinder_set(t_scene *scene, t_parse_list *lst)
 	lst_new = ft_calloc(sizeof(t_obj_list), 0);
 	cylinder = ft_calloc(sizeof(t_cylinder), 0);
 	obj_list_add_back(&scene->objects, lst_new);
-	cylinder->center = vec_get(lst_parse->point, 0, 0);
-	cylinder->normal = vec_get(lst_parse->nor_vec, -1, 1);
+	cylinder->center = vec_double_get(lst_parse->point, 0, 0);
+	cylinder->normal = vec_double_get(lst_parse->nor_vec, -1, 1);
 	cylinder->radius = double_get(lst_parse->diameter, 0, INFINITY) / 2;
 	cylinder->radius2 = cylinder->radius * cylinder->radius;
 	cylinder->height = double_get(lst_parse->height, 0, INFINITY);
 	lst_new->type = CYLINDER;
-	lst_new->color = vec_get(lst_parse->rgb, 0, 255);
+	lst_new->color = vec_int_get(lst_parse->rgb, 0, 255);
 	lst_new->object = cylinder;
 }

--- a/src_bonus/parse/parse_str_get_bonus.c
+++ b/src_bonus/parse/parse_str_get_bonus.c
@@ -23,7 +23,7 @@ t_obj_type	element_type_get(char *s)
 
 static t_color_type	obj_info_get(char **str, int len, int idx)
 {
-	if (len < idx)
+	if (len <= idx)
 		return (ERROR_LESS);
 	if (ft_strcmp(str[idx], "rgb") == 0)
 	{

--- a/src_bonus/parse/parse_to_num_bonus.c
+++ b/src_bonus/parse/parse_to_num_bonus.c
@@ -5,6 +5,19 @@
 #include <math.h>
 #include <stdlib.h>
 
+int	int_get(char *s, int min, int max)
+{
+	int		i;
+	t_res	res;
+
+	i = ft_atoi(s, &res);
+	if (res != CLEAN)
+		error_user("Number must came in correct type.\n");
+	if (i < min || i > max)
+		error_user("Number must came in standard range.\n");
+	return (i);
+}
+
 double	double_get(char *s, double min, double max)
 {
 	double	d;
@@ -26,7 +39,26 @@ double	double_get(char *s, double min, double max)
 	return (d);
 }
 
-struct s_vec3	vec_get(char *s, double min, double max)
+struct s_vec3	vec_int_get(char *s, int min, int max)
+{
+	struct s_vec3	vec;
+	char			*s_tmp;
+	char			*s_tmp_ptr;
+
+	s_tmp = ft_strdup(s);
+	s_tmp_ptr = s_tmp;
+	vec.x = int_get(ft_strsep(&s_tmp, ','), min, max);
+	vec.y = int_get(ft_strsep(&s_tmp, ','), min, max);
+	vec.z = int_get(ft_strsep(&s_tmp, ','), min, max);
+	if (ft_strsep(&s_tmp, ',') != NULL)
+		error_user("[r,g,b] elements must came in standard.\n");
+	if (min == 0 && max == 255)
+		vec = vec3_divide_scalar(vec, 255);
+	free(s_tmp_ptr);
+	return (vec);
+}
+
+struct s_vec3	vec_double_get(char *s, double min, double max)
 {
 	struct s_vec3	vec;
 	char			*s_tmp;
@@ -38,15 +70,13 @@ struct s_vec3	vec_get(char *s, double min, double max)
 	vec.y = double_get(ft_strsep(&s_tmp, ','), min, max);
 	vec.z = double_get(ft_strsep(&s_tmp, ','), min, max);
 	if (ft_strsep(&s_tmp, ',') != NULL)
-		error_user("[x,y,z] or [r,g,b] elements must came in standard.\n");
+		error_user("[x,y,z] elements must came in standard.\n");
 	if (min == -1 && max == 1)
 	{
 		if (vec3_length(vec) == 0.0)
 			error_user("Normalized vector must came in standard.\n");
 		vec = vec3_unit(vec);
 	}
-	else if (min == 0 && max == 255)
-		vec = vec3_divide_scalar(vec, 255);
 	free(s_tmp_ptr);
 	return (vec);
 }

--- a/src_bonus/scene/ambient_bonus.c
+++ b/src_bonus/scene/ambient_bonus.c
@@ -1,6 +1,5 @@
 #include "parse_bonus.h"
 
-// rgb가 실수로 들어올때에 대해 고민해봐야함
 t_ambient	ambient_set(t_parse_list *lst)
 {
 	t_parse		*lst_parse;
@@ -8,6 +7,6 @@ t_ambient	ambient_set(t_parse_list *lst)
 
 	lst_parse = lst->object;
 	ambient.light_ratio = double_get(lst_parse->bri_ratio, 0.0, 1.0);
-	ambient.light_color = vec_get(lst_parse->rgb, 0, 255);
+	ambient.light_color = vec_int_get(lst_parse->rgb, 0, 255);
 	return (ambient);
 }

--- a/src_bonus/scene/camera_bonus.c
+++ b/src_bonus/scene/camera_bonus.c
@@ -12,8 +12,8 @@ t_camera	camera_prev_set(t_scene *scene, t_parse_list *lst)
 	double		h_fov;
 
 	lst_parse = lst->object;
-	origin = vec_get(lst_parse->point, 0, 0);
-	direct = vec_get(lst_parse->nor_vec, -1, 1);
+	origin = vec_double_get(lst_parse->point, 0, 0);
+	direct = vec_double_get(lst_parse->nor_vec, -1, 1);
 	h_fov = double_get(lst_parse->fov, 0, 180);
 	camera = camera_set(&scene->canvas, origin, direct, h_fov);
 	return (camera);

--- a/src_bonus/scene/light_bonus.c
+++ b/src_bonus/scene/light_bonus.c
@@ -13,9 +13,9 @@ void	light_set(t_scene *scene, t_parse_list *lst)
 	lst_new = ft_calloc(sizeof(t_obj_list), 0);
 	light = ft_calloc(sizeof(t_light), 0);
 	obj_list_add_back(&scene->lights, lst_new);
-	light->origin = vec_get(lst_parse->point, 0, 0);
+	light->origin = vec_double_get(lst_parse->point, 0, 0);
 	light->bright_ratio = double_get(lst_parse->bri_ratio, 0.0, 1.0);
 	lst_new->type = POINT_LIGHT;
-	lst_new->color.color = vec_get(lst_parse->rgb, 0, 255);
+	lst_new->color.color = vec_int_get(lst_parse->rgb, 0, 255);
 	lst_new->object = light;
 }

--- a/src_bonus/scene/objects_bonus.c
+++ b/src_bonus/scene/objects_bonus.c
@@ -33,12 +33,12 @@ static t_xpm_image	*image_get(char *filename, void *mlx_ptr)
 static void	texture_get(t_obj_list *l, t_parse *p, void *mlx_ptr)
 {
 	if (p->texture_id == COLOR)
-		l->color.color = vec_get(p->rgb, 0, 255);
+		l->color.color = vec_int_get(p->rgb, 0, 255);
 	else if (p->texture_id == CHECKBOARD)
 	{
-		l->color.color = vec_get(p->rgb, 0, 255);
+		l->color.color = vec_int_get(p->rgb, 0, 255);
 		l->color.checkboard = ft_calloc(sizeof(t_checkboard), 0);
-		l->color.checkboard->check_color = vec_get(p->check_color, 0, 255);
+		l->color.checkboard->check_color = vec_int_get(p->check_color, 0, 255);
 		l->color.checkboard->width = double_get(p->check_width, 0, INFINITY);
 		l->color.checkboard->height = double_get(p->check_height, 0, INFINITY);
 	}
@@ -61,9 +61,9 @@ void	object_set(t_scene *scene, t_parse_list *lst, void *mlx_ptr)
 	lst_new = ft_calloc(sizeof(t_obj_list), 0);
 	object = ft_calloc(sizeof(t_object), 0);
 	obj_list_add_back(&scene->objects, lst_new);
-	object->center = vec_get(lst_parse->point, 0, 0);
+	object->center = vec_double_get(lst_parse->point, 0, 0);
 	if (lst_parse->id != SPHERE)
-		object->normal = vec_get(lst_parse->nor_vec, -1, 1);
+		object->normal = vec_double_get(lst_parse->nor_vec, -1, 1);
 	if (lst_parse->id != PLANE)
 	{
 		object->radius = double_get(lst_parse->diameter, 0, INFINITY) / 2;


### PR DESCRIPTION
- RGB 부분은 int값으로 받도록 수정
 ft_atoi 추가 및 int_get 추가
[R,G,B] 는 vec_int_get으로
나머지 vec3을 받는 부분은 vec_double_get으로 받도록 수정
-> [r,g,b]에서 정수 이외의 값은 에러처리

- ft_atof에서 소수부의 유효성 확인 수정
소수부가 overflow가 되서 inf값이 되지 않도록 하였습니다.
inf값 이전까지 숫자를 할당하고, 그 뒤에 있는 숫자는 할당하지 않도록 하였습니다.
할당하지 않더라도 뒤에 있는 숫자부분은 유효성 확인은 하도록 하였습니다.

- object에서 color type이 없을 경우 세그폴트 수정
obj_info_get 함수에서 부등호 기호를 수정하였습니다.

- closes #99 
- closes #101 
- closes #102